### PR TITLE
Update the log-router chart to accept custom volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ Flags:
 | `interval`                               | How often to check for config changes (seconds)                 | `45`          |
 | `meta.key`                               | The metadata key (optional)                 | `""`                                |
 | `meta.values`                            | Metadata to use for the key   | `{}`
+| `extraVolumeMounts`                      | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |          |
+| `extraVolume`                            | Extra volume                               |                                                            | 
 | `fluentdResources`                       | Resource definitions for the fluentd container                 | `{}`|
 | `reloaderResources`                      | Resource definitions for the reloader container              | `{}`                     |
 | `tolerations`                            | Pod tolerations             | `[]`                     |

--- a/README.md
+++ b/README.md
@@ -340,8 +340,8 @@ Flags:
 | `interval`                               | How often to check for config changes (seconds)                 | `45`          |
 | `meta.key`                               | The metadata key (optional)                 | `""`                                |
 | `meta.values`                            | Metadata to use for the key   | `{}`
-| `extraVolumeMounts`                      | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |          |
-| `extraVolume`                            | Extra volume                               |                                                            | 
+| `extraVolumeMounts`                      | Mount extra volumes, required to mount ssl certificates when elasticsearch has tls enabled |          |
+| `extraVolumes`                           | Extra volumes                               |                                                            | 
 | `fluentdResources`                       | Resource definitions for the fluentd container                 | `{}`|
 | `reloaderResources`                      | Resource definitions for the reloader container              | `{}`                     |
 | `tolerations`                            | Pod tolerations             | `[]`                     |

--- a/log-router/Chart.yaml
+++ b/log-router/Chart.yaml
@@ -4,4 +4,4 @@
 apiVersion: v1
 description: Distribution of Fluentd as K8S daemonset
 name: log-router
-version: 0.2.0
+version: 0.2.1

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -38,6 +38,9 @@ spec:
           - name: varlibdockercontainers
             mountPath: /var/lib/docker/containers
             readOnly: true
+{{- if .Values.extraVolumeMounts }}          
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+{{- end }}
           resources:
 {{ toYaml .Values.fluentdResources | indent 12 }}
 
@@ -89,3 +92,6 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+{{- if .Values.extraVolumes }}          
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}

--- a/log-router/values.yaml
+++ b/log-router/values.yaml
@@ -25,6 +25,16 @@ meta:
   key: ""
   values: {}
 
+# extraVolumes:
+#   - name: es-certs
+#     secret:
+#       defaultMode: 420
+#       secretName: es-certs
+# extraVolumeMounts:
+#   - name: es-certs
+#     mountPath: /certs
+#     readOnly: true
+
 tolerations: []
 fluentdResources: {}
 reloaderResources: {}


### PR DESCRIPTION
Hi! Here it is 😃 

I didn't update the following line in the README:
`CHART_URL='https://github.com/vmware/kube-fluentd-operator/releases/download/v1.1.0-beta-1/log-router-0.2.0.tgz'`

Since for that you need to release the chart embbeded in a .tgz (version 0.2.1)