### PR TITLE
Add fluent-plugin-splunkhec to base-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ All logs originating from a file look exactly as all other Kubernetes logs. Howe
 * fluent-plugin-route
 * fluent-plugin-s3
 * fluent-plugin-secure-forward
+* fluent-plugin-splunkhec
 * fluent-plugin-systemd
 
 When customizing the image be careful not to uninstall plugins that are used internally to implement the macro language.

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -44,6 +44,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && fluent-gem install fluent-plugin-route \
     && fluent-gem install fluent-plugin-s3 \
     && fluent-gem install fluent-plugin-secure-forward \
+    && fluent-gem install fluent-plugin-splunkhec \
     && fluent-gem install fluent-plugin-systemd \
     && fluent-gem install logfmt \
     && SUDO_FORCE_REMOVE=yes \


### PR DESCRIPTION
This PR installs the fluent-plugin-splunkhec gem which allows for sending logs to the Splunk HTTP Event Collector.