### PR TITLE
Installing additional fluentd plugins in base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,12 +434,15 @@ All logs originating from a file look exactly as all other Kubernetes logs. Howe
 * fluent-plugin-detect-exceptions
 * fluent-plugin-elasticsearch
 * fluent-plugin-google-cloud
+* fluent-plugin-kafka
 * fluent-plugin-kinesis
 * fluent-plugin-kubernetes
 * fluent-plugin-kubernetes_metadata_filter
 * fluent-plugin-logentries
 * fluent-plugin-loggly
 * fluent-plugin-logzio
+* fluent-plugin-mail
+* fluent-plugin-mongo
 * fluent-plugin-out-http-ext
 * fluent-plugin-papertrail
 * fluent-plugin-parser
@@ -450,6 +453,7 @@ All logs originating from a file look exactly as all other Kubernetes logs. Howe
 * fluent-plugin-rewrite-tag-filter
 * fluent-plugin-route
 * fluent-plugin-s3
+* fluent-plugin-scribe
 * fluent-plugin-secure-forward
 * fluent-plugin-splunkhec
 * fluent-plugin-sumologic_output

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -29,12 +29,15 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && fluent-gem install fluent-plugin-detect-exceptions \
     && fluent-gem install fluent-plugin-elasticsearch \
     && fluent-gem install fluent-plugin-google-cloud \
+    && fluent-gem install fluent-plugin-kafka \
     && fluent-gem install fluent-plugin-kinesis \
     && fluent-gem install fluent-plugin-kubernetes \
     && fluent-gem install fluent-plugin-kubernetes_metadata_filter \
     && fluent-gem install fluent-plugin-logentries \
     && fluent-gem install fluent-plugin-loggly \
     && fluent-gem install fluent-plugin-logzio \
+    && fluent-gem install fluent-plugin-mail \
+    && fluent-gem install fluent-plugin-mongo \
     && fluent-gem install fluent-plugin-out-http-ext \
     && fluent-gem install fluent-plugin-papertrail \
     && fluent-gem install fluent-plugin-parser \
@@ -45,6 +48,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && fluent-gem install fluent-plugin-rewrite-tag-filter \
     && fluent-gem install fluent-plugin-route \
     && fluent-gem install fluent-plugin-s3 \
+    && fluent-gem install fluent-plugin-scribe \
     && fluent-gem install fluent-plugin-secure-forward \
     && fluent-gem install fluent-plugin-splunkhec \
     && fluent-gem install fluent-plugin-sumologic_output \


### PR DESCRIPTION
Installing additional output plug-ins in base image:

- plugin for Apache Kafka > 0.8
- flowcounter plugin which counts messages/bytes that matches, per minutes/hours/days
- plugin which sends events to Amazon Kinesis
- plugin for mongoDB
- plugin to handle Facebook scribed thrift protocol
- plugin for mail
- plugin for influxdb
- plugin to count the number of matched messages, and emit if exceeds the threshold
- plugin for GrowthForecast
