### PR TITLE
Add pod annotation parameter for daemonset template

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ Flags:
 | `tolerations`                            | Pod tolerations             | `[]`                     |
 | `extraEnv`                               | Extra env vars to pass to fluentd           | `{}`                     |
 | `updateStrategy`                         | UpdateStrategy for the daemonset. Leave empty to get the K8S' default (probably the safest choice)            | `{}`                     |
+| `podAnnotations`                         | Pod annotations for the daemonset  |                    |
 
 ## Cookbook
 

--- a/log-router/Chart.yaml
+++ b/log-router/Chart.yaml
@@ -4,4 +4,4 @@
 apiVersion: v1
 description: Distribution of Fluentd as K8S daemonset
 name: log-router
-version: 0.2.4
+version: 0.2.5

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app: {{ template "fluentd-router.name" . }}
         release: {{ .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:

--- a/log-router/values.yaml
+++ b/log-router/values.yaml
@@ -52,3 +52,7 @@ reloaderResources: {}
   #  memory: 128Mi
 
 updateStrategy: {}
+
+## Annotations to add to the DaemonSet's Pods
+#podAnnotations:
+#  scheduler.alpha.kubernetes.io/tolerations: '[{"key": "example", "value": "foo"}]'


### PR DESCRIPTION
In my use case(fluent-s3-plugin),  I need to attach the IAM role to the pod with kubernetes annotation with [kube2iam](https://github.com/jtblin/kube2iam).

So, I added annotation parameter for daemonset template.