### PR TITLE
Multiple configmaps per namespace support

### DIFF
--- a/config-reloader/config/config.go
+++ b/config-reloader/config/config.go
@@ -9,11 +9,10 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
 	"github.com/vmware/kube-fluentd-operator/config-reloader/util"
-
 	"github.com/alecthomas/kingpin"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var (
@@ -40,12 +39,14 @@ type Config struct {
 	FluentdValidateCommand string
 	MetaKey                string
 	MetaValues             string
+	LabelSelector          string
 	KubeletRoot            string
 	Namespaces             []string
 	PrometheusEnabled      bool
 	// parsed or processed/cached fields
-	level            logrus.Level
-	ParsedMetaValues map[string]string
+	level               logrus.Level
+	ParsedMetaValues    map[string]string
+	ParsedLabelSelector labels.Set
 }
 
 var defaultConfig = &Config{
@@ -128,7 +129,7 @@ func (cfg *Config) Validate() error {
 			}
 			kvp := strings.Split(ele, "=")
 			if len(kvp) != 2 {
-				return fmt.Errorf("Bad metadata: %s, use the k=v,k2=v2... format", cfg.MetaValues)
+				return fmt.Errorf("bad metadata: %s, use the k=v,k2=v2... format", cfg.MetaValues)
 			}
 			k := util.Trim(kvp[0])
 			v := util.Trim(kvp[1])
@@ -141,6 +142,34 @@ func (cfg *Config) Validate() error {
 		if len(cfg.ParsedMetaValues) == 0 {
 			return errors.New("using --meta-key requires --meta-values too")
 		}
+	}
+
+	if cfg.Datasource == "multimap" {
+
+		if cfg.LabelSelector == "" {
+			return errors.New("using --datasource=multimap requires --label-selector too")
+		}
+
+		parsed := map[string]string{}
+		values := strings.Split(cfg.LabelSelector, ",")
+
+		for _, ele := range values {
+			if len(ele) == 0 {
+				// trailing or double ,,
+				continue
+			}
+			kvp := strings.Split(ele, "=")
+			if len(kvp) != 2 {
+				return fmt.Errorf("bad label selector: %s, use the k=v,k2=v2... format", cfg.MetaValues)
+			}
+			k := util.Trim(kvp[0])
+			v := util.Trim(kvp[1])
+
+			if isValid(k) && isValid(v) {
+				parsed[k] = v
+			}
+		}
+		cfg.ParsedLabelSelector = labels.Set(parsed)
 	}
 
 	return nil
@@ -182,6 +211,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("meta-values", "Metadata in the k=v,k2=v2 format").StringVar(&cfg.MetaValues)
 
 	app.Flag("fluentd-binary", "Path to fluentd binary used to validate configuration").StringVar(&cfg.FluentdValidateCommand)
+
+	app.Flag("label-selector", "Label selector in the k=v,k2=v2 format (used only with 'multimap' datasource)").StringVar(&cfg.LabelSelector)
 	_, err := app.Parse(args)
 
 	if err != nil {

--- a/config-reloader/config/config.go
+++ b/config-reloader/config/config.go
@@ -155,7 +155,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("master", "The Kubernetes API server to connect to (default: auto-detect)").Default(defaultConfig.Master).StringVar(&cfg.Master)
 	app.Flag("kubeconfig", "Retrieve target cluster configuration from a Kubernetes configuration file (default: auto-detect)").Default(defaultConfig.KubeConfig).StringVar(&cfg.KubeConfig)
 
-	app.Flag("datasource", "Datasource to use").Default("default").EnumVar(&cfg.Datasource, "default", "fake", "fs")
+	app.Flag("datasource", "Datasource to use").Default("default").EnumVar(&cfg.Datasource, "default", "fake", "fs", "multimap")
 	app.Flag("fs-dir", "If datasource=fs is used, configure the dir hosting the files").StringVar(&cfg.FsDatasourceDir)
 
 	app.Flag("interval", "Run every x seconds").Default(strconv.Itoa(defaultConfig.IntervalSeconds)).IntVar(&cfg.IntervalSeconds)

--- a/config-reloader/config/config.go
+++ b/config-reloader/config/config.go
@@ -184,8 +184,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("master", "The Kubernetes API server to connect to (default: auto-detect)").Default(defaultConfig.Master).StringVar(&cfg.Master)
 	app.Flag("kubeconfig", "Retrieve target cluster configuration from a Kubernetes configuration file (default: auto-detect)").Default(defaultConfig.KubeConfig).StringVar(&cfg.KubeConfig)
 
-	app.Flag("datasource", "Datasource to use").Default("default").EnumVar(&cfg.Datasource, "default", "fake", "fs", "multimap")
-	app.Flag("fs-dir", "If datasource=fs is used, configure the dir hosting the files").StringVar(&cfg.FsDatasourceDir)
+	app.Flag("datasource", "Datasource to use default|fake|fs|multimap (default: default) ").Default("default").EnumVar(&cfg.Datasource, "default", "fake", "fs", "multimap")
+	app.Flag("fs-dir", "If --datasource=fs is used, configure the dir hosting the files").StringVar(&cfg.FsDatasourceDir)
 
 	app.Flag("interval", "Run every x seconds").Default(strconv.Itoa(defaultConfig.IntervalSeconds)).IntVar(&cfg.IntervalSeconds)
 
@@ -212,7 +212,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 
 	app.Flag("fluentd-binary", "Path to fluentd binary used to validate configuration").StringVar(&cfg.FluentdValidateCommand)
 
-	app.Flag("label-selector", "Label selector in the k=v,k2=v2 format (used only with 'multimap' datasource)").StringVar(&cfg.LabelSelector)
+	app.Flag("label-selector", "Label selector in the k=v,k2=v2 format (used only with --datasource=multimap)").StringVar(&cfg.LabelSelector)
 	_, err := app.Parse(args)
 
 	if err != nil {

--- a/config-reloader/controller/controller.go
+++ b/config-reloader/controller/controller.go
@@ -49,7 +49,11 @@ func New(cfg *config.Config) (*Controller, error) {
 	} else if cfg.Datasource == "fs" {
 		ds = datasource.NewFileSystemDatasource(cfg.FsDatasourceDir, cfg.OutputDir)
 	} else {
-		ds, err = datasource.NewKubernetesDatasource(cfg)
+		if cfg.Datasource == "multimap" {
+			ds, err = datasource.NewKubernetesMultimapDatasource(cfg)
+		} else {
+			ds, err = datasource.NewKubernetesDatasource(cfg)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/config-reloader/datasource/kube_multimap.go
+++ b/config-reloader/datasource/kube_multimap.go
@@ -1,0 +1,182 @@
+// Copyright © 2018 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package datasource
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/vmware/kube-fluentd-operator/config-reloader/config"
+
+	"github.com/sirupsen/logrus"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"fmt"
+)
+
+type kubeMultimapConnection struct {
+	client kubernetes.Interface
+	hashes map[string]string
+	cfg    *config.Config
+}
+
+func (d *kubeMultimapConnection) readConfig(namespace string, maps *core.ConfigMapList) (string, error) {
+	contents := ""
+	for _, configMap := range maps.Items {
+		if _, ok := configMap.Annotations[d.cfg.AnnotConfigmapName]; ok {
+			mapData, ok := configMap.Data[entryName]
+			if ok {
+				contents = fmt.Sprintf("%s\n%s", contents, mapData)
+				logrus.Debugf("loaded config data from config map %s/%s", namespace, configMap.Name)
+			} else {
+				logrus.Warnf("cannot find entry %s in config map %s/%s", entryName, namespace, configMap.Name)
+			}
+		}
+	}
+
+	return contents, nil
+}
+
+func (d *kubeMultimapConnection) unconfiguredNamespace(ns string) *NamespaceConfig {
+	return &NamespaceConfig{
+		Name:               ns,
+		FluentdConfig:      "",
+		PreviousConfigHash: d.hashes[ns],
+	}
+}
+
+func (d *kubeMultimapConnection) GetNamespaces() ([]*NamespaceConfig, error) {
+	resp, err := d.client.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*NamespaceConfig
+	for _, item := range resp.Items {
+		maps, err := d.client.CoreV1().ConfigMaps(item.Name).List(metav1.ListOptions{})
+		if err != nil {
+			logrus.Debugf("will not process namespace '%s': %+v", item.Name, err)
+			result = append(result, d.unconfiguredNamespace(item.Name))
+			continue
+		}
+
+		if !d.needsProcessing(item.Name, maps) {
+			continue
+		}
+
+		contents, err := d.readConfig(item.Name, maps)
+		if err != nil {
+			logrus.Debugf("will not process namespace '%s': %+v", item.Name, err)
+			result = append(result, d.unconfiguredNamespace(item.Name))
+			continue
+		}
+
+		logrus.Debugf("processing namespace '%s'", item.Name)
+
+		obj := &NamespaceConfig{
+			Name:               item.Name,
+			FluentdConfig:      contents,
+			PreviousConfigHash: d.hashes[item.Name],
+			IsKnownFromBefore:  true,
+			Labels:             item.Labels,
+		}
+
+		resp, err := d.client.CoreV1().Pods(item.Name).List(metav1.ListOptions{})
+		if err == nil {
+			obj.MiniContainers = convertPodToMinis(resp)
+		} else {
+			logrus.Infof("Cannot read pods in namespace '%s'", item.Name)
+		}
+
+		result = append(result, obj)
+	}
+
+	return result, nil
+}
+
+func (d *kubeMultimapConnection) needsProcessing(ns string, maps *core.ConfigMapList) bool {
+	if len(d.cfg.Namespaces) == 0 {
+		if d.containsProcessableMap(maps) {
+			return true
+		}
+		logrus.Debugf("ignoring namespace '%s' because it doesn't contain any processable map", ns)
+		return false
+	}
+
+	for _, item := range d.cfg.Namespaces {
+		if item == ns {
+			if d.containsProcessableMap(maps) {
+				return true
+			}
+			logrus.Debugf("ignoring namespace '%s' because it doesn't contain any processable map", ns)
+			return false
+		}
+	}
+
+	logrus.Debugf("ignoring namespace '%s' because of --namespaces flag", ns)
+	return false
+}
+
+func (d *kubeMultimapConnection) containsProcessableMap(maps *core.ConfigMapList) (bool) {
+	for _, configMap := range maps.Items {
+		if _, ok := configMap.Annotations[d.cfg.AnnotConfigmapName]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+
+func (d *kubeMultimapConnection) WriteCurrentConfigHash(namespace string, hash string) {
+	d.hashes[namespace] = hash
+}
+
+func (d *kubeMultimapConnection) UpdateStatus(namespace string, status string) {
+	patch := &core.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+			Annotations: map[string]string{
+				d.cfg.AnnotStatus: status,
+			},
+		},
+	}
+
+	body, _ := json.Marshal(&patch)
+	_, err := d.client.CoreV1().Namespaces().Patch(namespace, types.MergePatchType, body)
+
+	logrus.Debugf("Saving status: %+v, %+v", patch, err)
+	if err != nil {
+		logrus.Infof("Cannot set error status of %s: %v", namespace, err)
+	}
+}
+
+func NewKubernetesMultimapDatasource(cfg *config.Config) (Datasource, error) {
+	kubeConfig := cfg.KubeConfig
+	if cfg.KubeConfig == "" {
+		if _, err := os.Stat(clientcmd.RecommendedHomeFile); err == nil {
+			kubeConfig = clientcmd.RecommendedHomeFile
+		}
+	}
+
+	kubeCfg, err := clientcmd.BuildConfigFromFlags(cfg.Master, kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := kubernetes.NewForConfig(kubeCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Connected to cluster at %s", kubeCfg.Host)
+
+	return &kubeMultimapConnection{
+		client: client,
+		hashes: make(map[string]string),
+		cfg:    cfg,
+	}, nil
+}

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -82,6 +82,7 @@ spec:
           {{- end }}
           command:
           -  /bin/config-reloader
+          - --datasource={{ .Values.datasource }}
           - --interval={{ .Values.interval }}
           - --log-level={{ .Values.logLevel }}
           - --output-dir=/fluentd/etc
@@ -98,6 +99,10 @@ spec:
           {{- end }}
           {{- if .Values.prometheusEnabled }}
           - --prometheus-enabled
+          {{- end }}
+          {{- if and (eq .Values.datasource "multimap") .Values.labelSelector.matchLabels }}
+          - --label-selector={{- range $k, $v := .Values.labelSelector.matchLabels }}{{$k}}={{$v}},
+          {{- end }}
           {{- end }}
           {{- range  .Values.namespaces }}
           - --namespaces

--- a/log-router/values.yaml
+++ b/log-router/values.yaml
@@ -10,6 +10,9 @@ rbac:
 
 serviceAccountName: "default"
 
+# Possible values: default|fake|fs|multimap
+datasource: default
+
 image:
   repository: vmware/kube-fluentd-operator
   pullPolicy: IfNotPresent
@@ -24,6 +27,12 @@ kubeletRoot: /var/lib/kubelet
 meta:
   key: ""
   values: {}
+
+# Use with datasource: multimap, the label selector will be used for finding ConfigMaps inside
+# the Namespaces in order to compile the Namespace fluentd configuration. The simple concatenation
+# is used and the ConfigMap is then processed for macros.
+labelSelector:
+  matchLabels: {}
 
 #extraVolumes:
 #   - name: es-certs


### PR DESCRIPTION
I would like to hear your feedback on this as this feature is very needed in our environment where each service deployment (as Helm Chart) should be able to configure logging for itself. So I ve got this Idea with a new Datasource which would support that.

Datasource:
* List namespaces
* List ConfigMaps in a namespace
* Checks for Annotation presence
* If present merge configuration to per-namespace configuration