### PR TITLE
Install AMQP plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ All logs originating from a file look exactly as all other Kubernetes logs. Howe
 
 `kube-fluentd-operator` aims to be easy to use and flexible. It also favors appending logs to multiple destinations using `<copy>` and as such comes with many plugins pre-installed:
 
-* fluent-plugin-amqp2
+* fluent-plugin-amqp
 * fluent-plugin-concat
 * fluent-plugin-detect-exceptions
 * fluent-plugin-elasticsearch

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -25,7 +25,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
      $buildDeps \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && fluent-gem install ffi \
-    && fluent-gem install fluent-plugin-amqp2 \
+    && fluent-gem install fluent-plugin-amqp \
     && fluent-gem install fluent-plugin-concat \
     && fluent-gem install fluent-plugin-detect-exceptions \
     && fluent-gem install fluent-plugin-elasticsearch \


### PR DESCRIPTION
AMQP plugin once again. The other version of the plugin is almost useless as it does not allow configuration of rounting_key nor handle SSL at all. We are actually using this version currently, using the other was a mistake sorry for that.