### PR TITLE
Some parameters of helm chart can be set in each container

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,12 +545,14 @@ Flags:
 | `interval`                               | How often to check for config changes (seconds)                 | `45`          |
 | `meta.key`                               | The metadata key (optional)                 | `""`                                |
 | `meta.values`                            | Metadata to use for the key   | `{}`
-| `extraVolumeMounts`                      | Mount extra volumes, required to mount ssl certificates when elasticsearch has tls enabled |          |
 | `extraVolumes`                           | Extra volumes                               |                                                            |
-| `fluentdResources`                       | Resource definitions for the fluentd container                 | `{}`|
-| `reloaderResources`                      | Resource definitions for the reloader container              | `{}`                     |
+| `fluentd.extraVolumeMounts`              | Mount extra volumes for the fluentd container, required to mount ssl certificates when elasticsearch has tls enabled |          |
+| `fluentd.resources`                      | Resource definitions for the fluentd container                 | `{}`|
+| `fluentd.extraEnv`                       | Extra env vars to pass to the fluentd container           | `{}`                     |
+| `reloader.extraVolumeMounts`             | Mount extra volumes for the reloader container |          |
+| `reloader.resources`                     | Resource definitions for the reloader container              | `{}`                     |
+| `reloader.extraEnv`                      | Extra env vars to pass to the reloader container           | `{}`                     |
 | `tolerations`                            | Pod tolerations             | `[]`                     |
-| `extraEnv`                               | Extra env vars to pass to fluentd           | `{}`                     |
 | `updateStrategy`                         | UpdateStrategy for the daemonset. Leave empty to get the K8S' default (probably the safest choice)            | `{}`                     |
 | `podAnnotations`                         | Pod annotations for the daemonset  |                    |
 

--- a/log-router/Chart.yaml
+++ b/log-router/Chart.yaml
@@ -4,4 +4,4 @@
 apiVersion: v1
 description: Distribution of Fluentd as K8S daemonset
 name: log-router
-version: 0.2.5
+version: 0.2.6

--- a/log-router/Chart.yaml
+++ b/log-router/Chart.yaml
@@ -4,4 +4,4 @@
 apiVersion: v1
 description: Distribution of Fluentd as K8S daemonset
 name: log-router
-version: 0.2.6
+version: 0.3.0

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -18,8 +18,10 @@ spec:
       labels:
         app: {{ template "fluentd-router.name" . }}
         release: {{ .Release.Name }}
-      {{- if .Values.podAnnotations }}
       annotations:
+        checksum/fluentd-extraenv: {{ toYaml .Values.fluentd.extraEnv | sha256sum }}
+        checksum/reloader-extraenv: {{ toYaml .Values.reloader.extraEnv | sha256sum }}
+      {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
@@ -36,12 +38,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        {{- range $key, $value := .Values.extraEnv }}
+        {{- range $key, $value := .Values.fluentd.extraEnv }}
           - name: {{ $key }}
             valueFrom:
               secretKeyRef:
                 name: {{ template "fluentd-router.fullname" $root }}
-                key: {{ $key }}
+                key: fluentd.{{ $key }}
         {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.prometheusEnabled }}
@@ -60,15 +62,24 @@ spec:
           - name: varlibdockercontainers
             mountPath: /var/lib/docker/containers
             readOnly: true
-{{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+{{- if .Values.fluentd.extraVolumeMounts }}
+{{ toYaml .Values.fluentd.extraVolumeMounts | indent 10 }}
 {{- end }}
           resources:
-{{ toYaml .Values.fluentdResources | indent 12 }}
-
+{{ toYaml .Values.fluentd.resources | indent 12 }}
         - name: reloader
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.reloader.extraEnv }}
+          env:
+        {{- range $key, $value := .Values.reloader.extraEnv }}
+          - name: {{ $key }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fluentd-router.fullname" $root }}
+                key: reloader.{{ $key }}
+        {{- end }}
+          {{- end }}
           command:
           -  /bin/config-reloader
           - --interval={{ .Values.interval }}
@@ -95,8 +106,11 @@ spec:
           volumeMounts:
           - name: fluentconf
             mountPath: /fluentd/etc
+{{- if .Values.reloader.extraVolumeMounts }}
+{{ toYaml .Values.reloader.extraVolumeMounts | indent 10 }}
+{{- end }}
           resources:
-{{ toYaml .Values.reloaderResources | indent 12 }}
+{{ toYaml .Values.reloader.resources | indent 12 }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/log-router/templates/secret.yaml
+++ b/log-router/templates/secret.yaml
@@ -2,7 +2,7 @@
 Copyright © 2018 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 */}}
-{{- if .Values.extraEnv -}}
+{{- if (or (.Values.fluentd.extraEnv) (.Values.reloader.extraEnv)) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,10 +12,15 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    checksum/fluentd-extraenv: {{ toYaml .Values.fluentd.extraEnv | sha256sum }}
+    checksum/reloader-extraenv: {{ toYaml .Values.reloader.extraEnv | sha256sum }}
 type: Opaque
 data:
-{{- range $key, $value := .Values.extraEnv }}
-  {{ $key }}: {{ $value | b64enc | quote }}
+{{- range $key, $value := .Values.fluentd.extraEnv }}
+  fluentd.{{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- range $key, $value := .Values.reloader.extraEnv }}
+  reloader.{{ $key }}: {{ $value | b64enc | quote }}
 {{- end }}
 {{- end }}
-

--- a/log-router/values.yaml
+++ b/log-router/values.yaml
@@ -25,21 +25,34 @@ meta:
   key: ""
   values: {}
 
-extraEnv: {}
-
-# extraVolumes:
+#extraVolumes:
 #   - name: es-certs
 #     secret:
 #       defaultMode: 420
 #       secretName: es-certs
+
+#  - name: es-certs
+#    mountPath: /certs
+#    readOnly: true
+
+
+fluentd:
+  extraEnv: {}
+  resources: {}
 # extraVolumeMounts:
-#   - name: es-certs
-#     mountPath: /certs
-#     readOnly: true
+#  - name: es-certs
+#    mountPath: /certs
+#    readOnly: true
+
+reloader:
+  extraEnv: {}
+  resources: {}
+# extraVolumeMounts:
+#  - name: es-certs
+#    mountPath: /certs
+#    readOnly: true
 
 tolerations: []
-fluentdResources: {}
-reloaderResources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
Hi.
I modified helm chart, so please check it.

- ```extraEnv```,``` extraVolumeMounts``` can be set individually for fluentd and reloader
  - ```extraVolumeMounts```: When I use ```fluent-plugin-google-cloud```, it happened credential error in reloader, so I need ```extraVolumeMounts``` in reloader
    - ```error=\"Could not load the default credentials. Browse to\\nhttps://developers.google.com/accounts/docs/application-default-credentials```
   - ```extraEnv```:  I thought it would be useful, and added it.
- When ```env``` is updated, daemonset pods automatically update (if ```updateStrategy.type:rollingUpdate```)
  - add checksum for env value to annotation 