### PR TITLE
Add cloudwatch-logs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ All logs originating from a file look exactly as all other Kubernetes logs. Howe
 * fluent-config-regexp-type (1.0.0)
 * fluent-mixin-config-placeholders (0.4.0)
 * fluent-plugin-amqp (0.12.0)
+* fluent-plugin-cloudwatch-logs (0.7.3)
 * fluent-plugin-concat (2.3.0)
 * fluent-plugin-detect-exceptions (0.0.11)
 * fluent-plugin-elasticsearch (3.0.1)

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -27,6 +27,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && fluent-gem install ffi \
     && fluent-gem install fluent-plugin-amqp \
+    && fluent-gem install fluent-plugin-cloudwatch-logs \ 
     && fluent-gem install fluent-plugin-concat \
     && fluent-gem install fluent-plugin-detect-exceptions \
     && fluent-gem install fluent-plugin-elasticsearch \


### PR DESCRIPTION
This PR adds the cloudwatch-logs plugin. I have tested on a personal K8s cluster.

