### PR TITLE
Fix default docker repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -873,7 +873,7 @@ This will build the code, then `config-reloader` will connect to the K8S cluster
 
 ### I want to build a custom image with my own fluentd plugin
 
-Use the `vmware/kube-fluentd-operator:TAG` as a base and do any modification as usual. If this plugin is not top-secret consider sending us a patch :)
+Use the `jvassev/kube-fluentd-operator:TAG` as a base and do any modification as usual. If this plugin is not top-secret consider sending us a patch :)
 
 ### I run two clusters - in us-east-2 and eu-west-2. How to differentiate between them when pushing logs to a single location?
 

--- a/log-router/values.yaml
+++ b/log-router/values.yaml
@@ -14,7 +14,7 @@ serviceAccountName: "default"
 datasource: default
 
 image:
-  repository: vmware/kube-fluentd-operator
+  repository: jvassev/kube-fluentd-operator
   pullPolicy: IfNotPresent
   tag: latest
   pullSecret: ""
@@ -74,6 +74,7 @@ tolerations: []
   #  memory: 128Mi
 
 updateStrategy: {}
+#  type: RollingUpdate
 
 ## Annotations to add to the DaemonSet's Pods
 #podAnnotations:


### PR DESCRIPTION
The default docker repository in the Helm chart appears not to exist. I've also added a comment with the format of the updateStrategy field.