### PR TITLE
Add subPath support to mounted-file

### DIFF
--- a/config-reloader/datasource/datasource.go
+++ b/config-reloader/datasource/datasource.go
@@ -16,6 +16,7 @@ const (
 type Mount struct {
 	Path       string
 	VolumeName string
+	SubPath    string
 }
 
 // MiniContainer container subset with the parent pod's metadata
@@ -127,6 +128,7 @@ func makeVolume(volumes []core.Volume, volumeMount *core.VolumeMount) *Mount {
 			return &Mount{
 				VolumeName: v.Name,
 				Path:       volumeMount.MountPath,
+				SubPath:    volumeMount.SubPath,
 			}
 		}
 	}

--- a/config-reloader/processors/mounted_file.go
+++ b/config-reloader/processors/mounted_file.go
@@ -213,7 +213,7 @@ func (state *mountedFileState) makeHostPath(cf *ContainerFile, hm *datasource.Mo
 	// var/lib/kubelet/pods/8e0f9442-41b5-11e8-a138-02b2be114bba/volumes/kubernetes.io~empty-dir/empty/hello.log
 	volumentName := hm.VolumeName
 	subPath := cf.Path[len(hm.Path):]
-	return path.Join(state.Context.KubeletRoot, "pods", mc.PodID, "volumes", "kubernetes.io~empty-dir", volumentName, subPath)
+	return path.Join(state.Context.KubeletRoot, "pods", mc.PodID, "volumes", "kubernetes.io~empty-dir", volumentName, hm.SubPath, subPath)
 }
 
 func (state *mountedFileState) Process(input fluentd.Fragment) (fluentd.Fragment, error) {


### PR DESCRIPTION
If the `volumeMount` contains a `subPath` the generated `path` points to the wrong location.

Example pod fragment:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: example-pod
spec:
  containers:
    - name: busybox
      image: busybox
      volumeMounts:
        - mountPath: /var/log
          name: logs
          subPath: path
  volumes:
    - name: logs
      emptyDir: {}
```
This PR will fix this issue.