### PR TITLE
Allow any volume type and add subPath support to mounted-file

### DIFF
--- a/config-reloader/datasource/datasource.go
+++ b/config-reloader/datasource/datasource.go
@@ -124,7 +124,7 @@ func convertPodToMinis(resp *core.PodList) []*MiniContainer {
 
 func makeVolume(volumes []core.Volume, volumeMount *core.VolumeMount) *Mount {
 	for _, v := range volumes {
-		if v.Name == volumeMount.Name && v.EmptyDir != nil {
+		if v.Name == volumeMount.Name {
 			return &Mount{
 				VolumeName: v.Name,
 				Path:       volumeMount.MountPath,

--- a/config-reloader/datasource/datasource.go
+++ b/config-reloader/datasource/datasource.go
@@ -16,6 +16,7 @@ const (
 type Mount struct {
 	Path       string
 	VolumeName string
+	SubPath    string
 }
 
 // MiniContainer container subset with the parent pod's metadata
@@ -127,6 +128,7 @@ func makeVolume(volumes []core.Volume, volumeMount *core.VolumeMount) *Mount {
 			return &Mount{
 				VolumeName: v.Name,
 				Path:       volumeMount.MountPath,
+				SubPath:    volumeMount.SubPath,
 			}
 		}
 	}

--- a/config-reloader/processors/mounted_file.go
+++ b/config-reloader/processors/mounted_file.go
@@ -213,7 +213,7 @@ func (state *mountedFileState) makeHostPath(cf *ContainerFile, hm *datasource.Mo
 	// var/lib/kubelet/pods/8e0f9442-41b5-11e8-a138-02b2be114bba/volumes/kubernetes.io~empty-dir/empty/hello.log
 	volumentName := hm.VolumeName
 	subPath := cf.Path[len(hm.Path):]
-	return path.Join(state.Context.KubeletRoot, "pods", mc.PodID, "volumes", "kubernetes.io~empty-dir", volumentName, subPath)
+	return path.Join(state.Context.KubeletRoot, "pods", mc.PodID, "volumes", "kubernetes.io~empty-dir", volumentName, hm.SubPath, subPath)
 }
 
 func (state *mountedFileState) Process(input fluentd.Fragment) (fluentd.Fragment, error) {

--- a/config-reloader/processors/mounted_file.go
+++ b/config-reloader/processors/mounted_file.go
@@ -213,7 +213,7 @@ func (state *mountedFileState) makeHostPath(cf *ContainerFile, hm *datasource.Mo
 	// var/lib/kubelet/pods/8e0f9442-41b5-11e8-a138-02b2be114bba/volumes/kubernetes.io~empty-dir/empty/hello.log
 	volumentName := hm.VolumeName
 	subPath := cf.Path[len(hm.Path):]
-	return path.Join(state.Context.KubeletRoot, "pods", mc.PodID, "volumes", "kubernetes.io~empty-dir", volumentName, hm.SubPath, subPath)
+	return path.Join(state.Context.KubeletRoot, "pods", mc.PodID, "volumes", "*", volumentName, hm.SubPath, subPath)
 }
 
 func (state *mountedFileState) Process(input fluentd.Fragment) (fluentd.Fragment, error) {

--- a/config-reloader/processors/mounted_file_test.go
+++ b/config-reloader/processors/mounted_file_test.go
@@ -224,10 +224,10 @@ func TestConvertToFragment(t *testing.T) {
 
 	assert.Equal(t, "source", dir.Name)
 	assert.Equal(t, "tail", dir.Type())
-	assert.Equal(t, "/kubelet-root/pods/123-id/volumes/kubernetes.io~empty-dir/logs/redis.log", dir.Param("path"))
-	assert.Equal(t, "kube.monitoring.123.container-name-b3f8f41cab18c93a7c8057277947de0d1d76d1d6", dir.Param("tag"))
+	assert.Equal(t, "/kubelet-root/pods/123-id/volumes/*/logs/redis.log", dir.Param("path"))
+	assert.Equal(t, "kube.monitoring.123.container-name-1b0164f4e0229a5ba19ce429a68e244e7bd188ef", dir.Param("tag"))
 	assert.Equal(t, "parse", dir.Nested[0].Name)
-	assert.Equal(t, "/var/log/kfotail-b3f8f41cab18c93a7c8057277947de0d1d76d1d6.pos", dir.Param("pos_file"))
+	assert.Equal(t, "/var/log/kfotail-1b0164f4e0229a5ba19ce429a68e244e7bd188ef.pos", dir.Param("pos_file"))
 	assert.Equal(t, "none", dir.Nested[0].Type())
 
 	mod := result[1]
@@ -244,8 +244,8 @@ func TestConvertToFragment(t *testing.T) {
 
 	assert.Equal(t, "source", dir.Name)
 	assert.Equal(t, "tail", dir.Type())
-	assert.Equal(t, "/kubelet-root/pods/abc-id/volumes/kubernetes.io~empty-dir/logs/nginx.log", dir.Param("path"))
-	assert.Equal(t, "kube.monitoring.abc.nginx-82357fcda2cbd45c066d8a538cbf1f3e96b1ce6a", dir.Param("tag"))
+	assert.Equal(t, "/kubelet-root/pods/abc-id/volumes/*/logs/nginx.log", dir.Param("path"))
+	assert.Equal(t, "kube.monitoring.abc.nginx-e2494382cb107230086812b14c1970eedcd138d2", dir.Param("tag"))
 
 	mod = result[1]
 	assert.Equal(t, "filter", mod.Name)
@@ -258,8 +258,8 @@ func TestConvertToFragment(t *testing.T) {
 
 	assert.Equal(t, "source", dir.Name)
 	assert.Equal(t, "tail", dir.Type())
-	assert.Equal(t, "/kubelet-root/pods/abcd-id/volumes/kubernetes.io~empty-dir/logs/files/nginx.log", dir.Param("path"))
-	assert.Equal(t, "kube.monitoring.abcd.nginx-sub-47c6dc18d51fcc522768361782c12ee10ca66215", dir.Param("tag"))
+	assert.Equal(t, "/kubelet-root/pods/abcd-id/volumes/*/logs/files/nginx.log", dir.Param("path"))
+	assert.Equal(t, "kube.monitoring.abcd.nginx-sub-5383902a5a6533ad979ac5c0cbb1d5b9399c2120", dir.Param("tag"))
 
 	mod = result[1]
 	assert.Equal(t, "filter", mod.Name)
@@ -363,9 +363,9 @@ func TestProcessMountedFile(t *testing.T) {
 	prep, err := Prepare(input, ctx, state)
 	assert.Nil(t, err)
 	assert.Equal(t, 6, len(prep))
-	assert.Equal(t, "/kubelet-root/pods/123-id/volumes/kubernetes.io~empty-dir/logs/redis.log", prep[0].Param("path"))
-	assert.Equal(t, "/kubelet-root/pods/abc-id/volumes/kubernetes.io~empty-dir/logs/nginx.log", prep[2].Param("path"))
-	assert.Equal(t, "/kubelet-root/pods/abc-sub-id/volumes/kubernetes.io~empty-dir/logs/files/nginx.log", prep[4].Param("path"))
+	assert.Equal(t, "/kubelet-root/pods/123-id/volumes/*/logs/redis.log", prep[0].Param("path"))
+	assert.Equal(t, "/kubelet-root/pods/abc-id/volumes/*/logs/nginx.log", prep[2].Param("path"))
+	assert.Equal(t, "/kubelet-root/pods/abc-sub-id/volumes/*/logs/files/nginx.log", prep[4].Param("path"))
 
 	payload := prep.String()
 	assert.True(t, strings.Contains(payload, "'container_image'=>'image-c2'"))


### PR DESCRIPTION
A combination if #63 and #64:
- Fix: If the `volumeMount` contains a `subPath` the generated `path` points to the wrong location
- Allow to use not only `emptyDir` volumes but also any volume type