### PR TITLE
Performance Measurement and Improvement

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -19,11 +19,12 @@ ADD https://raw.githubusercontent.com/fluent/fluentd-kubernetes-daemonset/master
 ADD https://raw.githubusercontent.com/fluent/fluentd-kubernetes-daemonset/master/docker-image/v1.2/debian-elasticsearch/plugins/parser_multiline_kubernetes.rb /fluentd/plugins
 
 RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev wget" \
+    pluginDeps="curl net-tools htop libjemalloc1" \
      && apt-get update \
      && apt-get upgrade -y \
      && apt-get install \
      -y --no-install-recommends \
-     $buildDeps libjemalloc1 \
+     $buildDeps $pluginDeps \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && fluent-gem install ffi \
     && fluent-gem install fluent-plugin-amqp \
@@ -64,6 +65,8 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev wget" \
     && wget https://github.com/vmware/fluent-plugin-vmware-log-intelligence/releases/download/v1.0.0/fluent-plugin-vmware-log-intelligence-1.0.0.gem \
     && fluent-gem install --local fluent-plugin-vmware-log-intelligence-1.0.0.gem \
     && rm fluent-plugin-vmware-log-intelligence-1.0.0.gem \
+    && fluent-gem install typhoeus \
+    && fluent-gem install fluent-plugin-flowcounter-simple \
     && SUDO_FORCE_REMOVE=yes \
     apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \

--- a/config-reloader/config/config.go
+++ b/config-reloader/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	level               logrus.Level
 	ParsedMetaValues    map[string]string
 	ParsedLabelSelector labels.Set
+  TestPerformance        bool
 }
 
 var defaultConfig = &Config{
@@ -64,6 +65,7 @@ var defaultConfig = &Config{
 	IntervalSeconds:      60,
 	ID:                   "default",
 	PrometheusEnabled:    false,
+  TestPerformance:      false,
 }
 
 var reValidID = regexp.MustCompile("([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]")
@@ -213,6 +215,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("fluentd-binary", "Path to fluentd binary used to validate configuration").StringVar(&cfg.FluentdValidateCommand)
 
 	app.Flag("label-selector", "Label selector in the k=v,k2=v2 format (used only with --datasource=multimap)").StringVar(&cfg.LabelSelector)
+
+	app.Flag("test-performance", "Performance testing enabled (default: false)").BoolVar(&cfg.TestPerformance)
 	_, err := app.Parse(args)
 
 	if err != nil {

--- a/config-reloader/generator/generator.go
+++ b/config-reloader/generator/generator.go
@@ -108,7 +108,10 @@ func (g *Generator) renderMainFile(mainFile string, outputDir string, dest strin
 		MetaKey                 string
 		MetaValue               string
 		PreprocessingDirectives []string
-	}{}
+		TestPerformance         bool
+	}{
+		TestPerformance:        g.cfg.TestPerformance,
+	}
 
 	if g.cfg.MetaKey != "" {
 		model.MetaKey = g.cfg.MetaKey

--- a/config-reloader/templates/fluent.conf
+++ b/config-reloader/templates/fluent.conf
@@ -56,6 +56,15 @@
 {{- end }}
 #################
 
+{{ if .TestPerformance -}}
+#################
+# Testing Performance of Fluentd
+#################
+<match **>
+  @type flowcounter_simple
+  unit second
+</match>
+{{- end }}
 
 #################
 # Generated based on namespace annotations

--- a/config-reloader/templates/kubernetes-postprocess.conf
+++ b/config-reloader/templates/kubernetes-postprocess.conf
@@ -1,33 +1,16 @@
 # Query the API for extra metadata.
 <filter kubernetes.**>
   @type kubernetes_metadata
-  # If the logs begin with '{' and end with '}' then it's JSON so merge
-  # the JSON log field into the log event
-  merge_json_log true
-  preserve_json_log true
-</filter>
-
-# rewrite_tag_filter does not support nested fields like
-# kubernetes.container_name, so this exists to flatten the fields
-# so we can use them in our rewrite_tag_filter
-<filter kubernetes.**>
-  @type record_transformer
-  enable_ruby true
-
-  # use the format namespace.pod_name.container_name
-  <record>
-    kubernetes_namespace_container_name ${record["kubernetes"]["namespace_name"]}.${record["kubernetes"]["pod_name"]}.${record["kubernetes"]["container_name"]}
-    container_info ${record["docker"]["container_id"]}-${record["stream"]}
-  </record>
+  cache_size 10000
 </filter>
 
 # retag based on the namespace and container name of the log message
 <match kubernetes.**>
   @type rewrite_tag_filter
-  # Update the tag have a structure of kube.<namespace>.<containername>
+  # Update the tag have a structure of kube.<namespace>
 
   <rule>
-    key      kubernetes_namespace_container_name
+    key      $['kubernetes']['namespace_name']
     pattern  ^(.+)$
     tag      kube.$1
   </rule>
@@ -41,12 +24,6 @@
   <record>
     dummy_ ${record["kubernetes"]&.delete("master_url"); record["kubernetes"]&.delete("namespace_id"); if record["kubernetes"]&.has_key?("labels"); record["kubernetes"]["labels"].delete("pod-template-generation"); record["kubernetes"]["labels"].delete("controller-revision-hash");  record["kubernetes"]["labels"].delete("pod-template-hash"); end; nil}
   </record>
-</filter>
-
-# Remove the unnecessary field as the information is already available on other fields.
-<filter kube.*.*.*>
-  @type record_transformer
-  remove_keys kubernetes_namespace_container_name
 </filter>
 
 # Parse logs in the kube-system namespace using the kubernetes formatter.

--- a/config-reloader/templates/kubernetes.conf
+++ b/config-reloader/templates/kubernetes.conf
@@ -10,7 +10,6 @@
   read_from_head true
   <parse>
     @type json
-    time_format %Y-%m-%dT%H:%M:%S.%NZ
   </parse>
 </source>
 
@@ -167,8 +166,3 @@
     time_format %Y-%m-%dT%T.%L%Z
   </parse>
 </source>
-
-<filter kubernetes.**>
-  @type kubernetes_metadata
-  @id filter_kube_metadata
-</filter>

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -108,6 +108,9 @@ spec:
           - --namespaces
           - "{{ . }}"
           {{- end }}
+          {{- if .Values.perfTest }}
+          - --test-performance
+          {{- end }}
           volumeMounts:
           - name: fluentconf
             mountPath: /fluentd/etc

--- a/log-router/values.yaml
+++ b/log-router/values.yaml
@@ -23,6 +23,7 @@ image:
 logLevel: debug
 interval: 45
 kubeletRoot: /var/lib/kubelet
+perfTest: false
 
 meta:
   key: ""


### PR DESCRIPTION
Signed-off-by: Apurba Samanta <apu1111@gmail.com>

1. I have included two new plugins. One for measuring performance of fluentd and another for improving performance of elastic-plugin.
2. Added a new config option (--test-performance) to enable/disable performance plugin configuration.
3. I have measured the performance of current config with the help of newly installed plugin and found that the in_tail performance is capped around 5000 lines per second. Major bottleneck being time format regex under source-tail and adding and manipulating kubernetes metadata.
4. Did some changes to the templates to remove the bottlenecks and now the performance is much improved.
5. For measuring performance please use the following steps.
   A) Use a simple script in a docker container, which writes logs in stdout.
   B) Enable --test-performance through values.yaml.
   C) exec into the fluentd container and tail the /var/log/containers/<fluentd-container-name>.log file
6. Output of my test:

 ### Before Optimization:

**Log Writing Rate by Application:** 10000 lines/sec 
**Log Reading Rate by fluentd:** ~5000 lines/sec
**Plugin Output:**
```
{"log":"2019-07-04 10:23:35 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:5025\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:35.052084738Z"}
{"log":"2019-07-04 10:23:36 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:6028\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:36.075255986Z"}
{"log":"2019-07-04 10:23:37 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:4020\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:37.077507771Z"}
{"log":"2019-07-04 10:23:38 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:5024\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:38.08316789Z"}
{"log":"2019-07-04 10:23:39 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:5023\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:39.087850536Z"}
{"log":"2019-07-04 10:23:40 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:5024\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:40.088578405Z"}
{"log":"2019-07-04 10:23:41 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:5024\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:41.093132914Z"}
{"log":"2019-07-04 10:23:42 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:5024\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:42.098891175Z"}
{"log":"2019-07-04 10:23:43 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:4019\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:43.001034361Z"}
{"log":"2019-07-04 10:23:44 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:5024\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:44.001674573Z"}
{"log":"2019-07-04 10:23:45 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:5024\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:45.103659815Z"}
{"log":"2019-07-04 10:23:46 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:5024\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:23:46.106632221Z"}

```

### After Optimization:
**Log Writing Rate by Application:** 10000 lines/sec
**Log Reading Rate by fluentd:** 10000 lines/sec
**Plugin Output:**
```
{"log":"2019-07-04 10:37:09 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:9969\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:12.106999744Z"}
{"log":"2019-07-04 10:37:13 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:10228\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:13.076063205Z"}
{"log":"2019-07-04 10:37:14 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:10785\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:14.098429136Z"}
{"log":"2019-07-04 10:37:15 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:9412\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:15.022716038Z"}
{"log":"2019-07-04 10:37:16 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:10695\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:16.027554944Z"}
{"log":"2019-07-04 10:37:17 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:10119\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:17.073106675Z"}
{"log":"2019-07-04 10:37:18 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:9460\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:18.018078493Z"}
{"log":"2019-07-04 10:37:19 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:10265\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:19.024371294Z"}
{"log":"2019-07-04 10:37:20 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:10025\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:20.023109607Z"}
{"log":"2019-07-04 10:37:21 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:9355\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:21.035918572Z"}
{"log":"2019-07-04 10:37:22 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:10505\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:22.097407051Z"}
{"log":"2019-07-04 10:37:23 +0000 [info]: #0 plugin:out_flowcounter_simple\u0009count:10762\u0009indicator:num\u0009unit:second\n","stream":"stdout","time":"2019-07-04T10:37:23.109512099Z"}
```
