### PR TITLE
Allow the use of virtual plugin in store directive

### DIFF
--- a/config-reloader/processors/extract_plugins.go
+++ b/config-reloader/processors/extract_plugins.go
@@ -39,7 +39,7 @@ func (p *expandPluginsState) Process(input fluentd.Fragment) (fluentd.Fragment, 
 	}
 
 	f := func(d *fluentd.Directive, ctx *ProcessorContext) error {
-		if d.Name != "match" {
+		if d.Name != "match" && d.Name != "store" {
 			// only output plugins supported
 			return nil
 		}

--- a/config-reloader/processors/extract_plugins_test.go
+++ b/config-reloader/processors/extract_plugins_test.go
@@ -163,3 +163,107 @@ func TestNothingToExpand(t *testing.T) {
 	matchDir = processed[2]
 	assert.Equal(t, "some_type", matchDir.Type())
 }
+
+func TestExpandPluginsInCopyStore(t *testing.T) {
+	pluginDef := `
+<plugin p1>
+	@type es
+	username admin
+	buffer_path /hello/world
+	buffer_size 1m
+	<buffer>
+		@type file
+		path /var/log/fluentd.*.buffer
+	</buffer>
+</plugin>
+<plugin p2>
+	@type logzio
+</plugin>
+`
+
+	es, err := fluentd.ParseString(pluginDef)
+	assert.Nil(t, err)
+
+	// prepare context as if there is a plugin already defined in kube-system
+	g := &GenerationContext{
+		Plugins: map[string]*fluentd.Directive{
+			"p1": es[0],
+			"p2": es[1],
+		},
+	}
+
+	nsConf := `
+<filter **>
+  @type grep
+</filter>
+
+<match **>
+  @type copy
+
+  <store>
+    # this is reference to the p1 plugin
+    @type p1
+
+    # param is copied
+    param1 value1
+
+    # param is overriden
+    buffer_size 5m
+  </store>
+  <store>
+    @type p2
+  </store>
+  <store>
+    @type es
+  </store>
+</match>
+
+<match **>
+  @type some_type
+</match>
+	`
+
+	fragment, err := fluentd.ParseString(nsConf)
+	assert.Nil(t, err)
+
+	ctx := &ProcessorContext{
+		GenerationContext: g,
+		Namepsace:         "unit-test",
+		DeploymentID:      "whatever",
+	}
+
+	state := &expandPluginsState{}
+	state.SetContext(ctx)
+
+	processed, err := state.Process(fragment)
+	assert.Nil(t, err)
+
+	// fmt.Printf("Processed:\n%s\n", processed)
+	matchDir := processed[1]
+	assert.Equal(t, "copy", matchDir.Type())
+
+	// check first store component
+	matchStore := matchDir.Nested[0]
+	assert.Equal(t, "es", matchStore.Type())
+
+	// param that's not overriden
+	assert.Equal(t, "/hello/world", matchStore.Param("buffer_path"))
+
+	// param that's defined at the call site
+	assert.Equal(t, "value1", matchStore.Param("param1"))
+
+	// param that's overriden
+	assert.Equal(t, "5m", matchStore.Param("buffer_size"))
+
+	// nested content is present
+	assert.Equal(t, "buffer", matchStore.Nested[0].Name)
+	assert.Equal(t, "/var/log/fluentd.*.buffer", matchStore.Nested[0].Param("path"))
+
+	// check second store
+	matchStore = matchDir.Nested[1]
+	assert.Equal(t, "logzio", matchStore.Type())
+
+	// types not found in the generation context are not touched
+	matchDir = processed[2]
+	assert.Equal(t, "some_type", matchDir.Type())
+}


### PR DESCRIPTION
This PR adds the ability to use the virtual plugin (https://github.com/vmware/kube-fluentd-operator#reusing-output-plugin-definitions-since-v160) in the `store` directive as part of the `copy` type. 

This allows for:

kube-system:
```
<plugin default>
  ...
</plugin>
```

other namespaces:
```
<match **>
  @type copy
  <store>
     @type default
  </store>
  <store>
    # some other store
    ... 
  </store>
</match>
```