### PR TITLE
feature: Make default configmap configurable through helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ Flags:
 |------------------------------------------|-------------------------------------|---------------------------------------------------|
 | `rbac.create`                            | Create a serviceaccount+role, use if K8s is using RBAC        | `false`                  |
 | `serviceAccountName`                     | Reuse an existing service account                | `""`                                             |
+| `defaultConfigmap`                       | Read the configmap by this name if the namespace is not annotated | `"fluentd-config"` |
 | `image.repositiry`                       | Repository                 | `jvassev/kube-fluentd-operator`                              |
 | `image.tag`                              | Image tag                | `latest`                          |
 | `image.pullPolicy`                       | Pull policy                 | `Always`                             |

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -83,6 +83,7 @@ spec:
           command:
           -  /bin/config-reloader
           - --datasource={{ .Values.datasource }}
+          - --default-configmap={{ .Values.defaultConfigmap }}
           - --interval={{ .Values.interval }}
           - --log-level={{ .Values.logLevel }}
           - --output-dir=/fluentd/etc

--- a/log-router/values.yaml
+++ b/log-router/values.yaml
@@ -13,6 +13,8 @@ serviceAccountName: "default"
 # Possible values: default|fake|fs|multimap
 datasource: default
 
+defaultConfigmap: "fluentd-config"
+
 image:
   repository: jvassev/kube-fluentd-operator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
This makes the default configmap configurable through the helm chart