### PR TITLE
Fix labels not being rewritten in copy plugin

### DIFF
--- a/config-reloader/processors/relabel.go
+++ b/config-reloader/processors/relabel.go
@@ -28,7 +28,7 @@ func normalizeLabelName(ctx *ProcessorContext, label string) string {
 
 func (p *rewriteLabelsState) Process(input fluentd.Fragment) (fluentd.Fragment, error) {
 	normalizeAllLabels := func(d *fluentd.Directive, ctx *ProcessorContext) error {
-		if d.Name != "match" {
+		if d.Name != "match" && d.Name != "store" {
 			return nil
 		}
 


### PR DESCRIPTION
This small enhancement allows the "relabel" processor to normalize labels
also when the "relabel" plugin is not directly placed inside a match
directive but rather placed in a store directive. This is a valid config
that could derive from the necessity of demultiplexing logs to several
pipelines that still need to perform additional processing before
reaching the output.

Previously the labels inside a store directive would not be normalized while
the corresponding labels in the label directive would. This would lead to
fluentd complaining that the non-normalized label was non-existent as it
was not able to find the corresponding label directive.
This behavior could also allow to generate unexpected results as a label created
in a store directive could be generated to match a normalized label from a
different namespace. This would avoid any warnings from fluentd and would
effectively allow pushing logs from one namespace to another, which would break
the namespace isolation that this operator guarantees.

This issue is also described in vmware/kube-fluentd-operator#56