### PR TITLE
Add new processor to support tag expansion

### DIFF
--- a/config-reloader/config/config.go
+++ b/config-reloader/config/config.go
@@ -9,9 +9,10 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"github.com/vmware/kube-fluentd-operator/config-reloader/util"
+
 	"github.com/alecthomas/kingpin"
 	"github.com/sirupsen/logrus"
+	"github.com/vmware/kube-fluentd-operator/config-reloader/util"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -43,6 +44,7 @@ type Config struct {
 	KubeletRoot            string
 	Namespaces             []string
 	PrometheusEnabled      bool
+	AllowTagExpansion      bool
 	// parsed or processed/cached fields
 	level               logrus.Level
 	ParsedMetaValues    map[string]string
@@ -213,6 +215,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("fluentd-binary", "Path to fluentd binary used to validate configuration").StringVar(&cfg.FluentdValidateCommand)
 
 	app.Flag("label-selector", "Label selector in the k=v,k2=v2 format (used only with --datasource=multimap)").StringVar(&cfg.LabelSelector)
+
+	app.Flag("allow-tag-expansion", "Allow specifying tags in the format 'k.{a,b}.** k.c.**' (default: false)").BoolVar(&cfg.AllowTagExpansion)
 	_, err := app.Parse(args)
 
 	if err != nil {

--- a/config-reloader/generator/generator.go
+++ b/config-reloader/generator/generator.go
@@ -270,6 +270,7 @@ func (g *Generator) makeContext(ns *datasource.NamespaceConfig, genCtx *processo
 		MiniContainers:    ns.MiniContainers,
 		KubeletRoot:       g.cfg.KubeletRoot,
 		GenerationContext: genCtx,
+		AllowTagExpansion: g.cfg.AllowTagExpansion,
 	}
 	return ctx
 }

--- a/config-reloader/processors/detect_exceptions_test.go
+++ b/config-reloader/processors/detect_exceptions_test.go
@@ -59,6 +59,7 @@ func TestWithoutExceptions(t *testing.T) {
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
+		AllowTagExpansion: true,
 	}
 
 	s := `
@@ -96,6 +97,7 @@ func TestWithExceptions(t *testing.T) {
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
+		AllowTagExpansion: true,
 	}
 
 	s := `

--- a/config-reloader/processors/expand_tags.go
+++ b/config-reloader/processors/expand_tags.go
@@ -1,0 +1,121 @@
+package processors
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/vmware/kube-fluentd-operator/config-reloader/fluentd"
+)
+
+const (
+	tagRegex = `(?:[^\s{}()]*(?:(?:(?:{.*?})|(?:\(.*?\)))[^\s{}()]*)+)|(?:[^\s{}()]+(?:(?:(?:{.*?})|(?:\(.*?\)))[^\s{}()]*)*)`
+)
+
+type expandTagsState struct {
+	BaseProcessorState
+	tagMatcher *regexp.Regexp
+}
+
+func (p *expandTagsState) Process(input fluentd.Fragment) (fluentd.Fragment, error) {
+	f := func(d *fluentd.Directive, ctx *ProcessorContext) ([]*fluentd.Directive, error) {
+
+		if d.Name != "match" && d.Name != "filter" {
+			return []*fluentd.Directive{d}, nil
+		}
+
+		if p.tagMatcher == nil {
+			p.tagMatcher = regexp.MustCompile(tagRegex)
+		}
+
+		expandingTags := p.tagMatcher.FindAllString(d.Tag, -1)
+		remainders := p.tagMatcher.Split(d.Tag, -1)
+
+		if len(strings.TrimSpace(strings.Join(remainders, ""))) > 0 {
+			return nil, fmt.Errorf("Malformed tag %s. Cannot parse it", d.Tag)
+		}
+
+		var processingTags []string
+
+		for len(expandingTags) > len(processingTags) {
+			processingTags = expandingTags
+			expandingTags = []string{}
+			for _, t := range processingTags {
+				expandedTags, err := expandFirstCurlyBraces(t)
+				if err != nil {
+					return nil, err
+				}
+
+				expandingTags = append(expandingTags, expandedTags...)
+			}
+		}
+
+		if len(expandingTags) == 1 {
+			return []*fluentd.Directive{d}, nil
+		}
+
+		expandedDirectives := make([]*fluentd.Directive, len(expandingTags))
+		for i, t := range expandingTags {
+			expandedDirectives[i] = d.Clone()
+			expandedDirectives[i].Tag = t
+		}
+
+		return expandedDirectives, nil
+	}
+
+	output, err := applyRecursivelyWithState(input, p.Context, f)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func expandFirstCurlyBraces(tag string) ([]string, error) {
+	resultingTags := []string{}
+	if open := strings.Index(tag, "{"); open >= 0 {
+		if open > 0 && tag[open-1:open] == "#" {
+			return nil, errors.New("Pattern #{...} is not yet supported in tag definition")
+		}
+		if close := strings.Index(tag, "}"); close > open+1 {
+			expansionTerm := tag[open+1 : close]
+			expansionTerms := strings.Split(expansionTerm, ",")
+
+			for _, t := range expansionTerms {
+				resultingTags = append(resultingTags, tag[:open]+strings.TrimSpace(t)+tag[close+1:])
+			}
+		} else {
+			return nil, errors.New("Invalid {...} pattern in tag definition")
+		}
+	} else {
+		resultingTags = append(resultingTags, tag)
+	}
+
+	return resultingTags, nil
+}
+
+func applyRecursivelyWithState(directives fluentd.Fragment, ctx *ProcessorContext, callback func(*fluentd.Directive, *ProcessorContext) ([]*fluentd.Directive, error)) (fluentd.Fragment, error) {
+	if directives == nil {
+		return nil, nil
+	}
+
+	for _, d := range directives {
+		output, err := applyRecursivelyWithState(d.Nested, ctx, callback)
+		if err != nil {
+			return nil, err
+		}
+		d.Nested = output
+	}
+
+	newDirectives := []*fluentd.Directive{}
+	for _, d := range directives {
+		output, err := callback(d, ctx)
+		if err != nil {
+			return nil, err
+		}
+		newDirectives = append(newDirectives, output...)
+	}
+
+	return newDirectives, nil
+}

--- a/config-reloader/processors/expand_tags_test.go
+++ b/config-reloader/processors/expand_tags_test.go
@@ -1,0 +1,119 @@
+package processors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/vmware/kube-fluentd-operator/config-reloader/fluentd"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagsExpandOk(t *testing.T) {
+	var input = []string{
+		`<match kube.monitoring.{app1,app2}.** kube.monitoring.app3.**>
+			@type null
+		</match>`,
+		`<filter kube.monitoring.{app1, app2}.**  kube.monitoring.app3.**>
+	  		@type null
+		</filter>`,
+	}
+
+	for _, s := range input {
+		fragment, err := fluentd.ParseString(s)
+		assert.Nil(t, err)
+
+		fmt.Printf("Original:\n%s", fragment)
+
+		ctx := &ProcessorContext{
+			Namepsace:         "monitoring",
+			GenerationContext: &GenerationContext{},
+		}
+		fragment, err = Process(fragment, ctx, &expandTagsState{})
+		assert.Nil(t, err)
+		assert.Equal(t, len(fragment), 3)
+		fmt.Printf("Processed:\n%s", fragment)
+
+		app1 := fragment[0]
+		assert.Equal(t, "kube.monitoring.app1.**", app1.Tag)
+
+		app2 := fragment[1]
+		assert.Equal(t, "kube.monitoring.app2.**", app2.Tag)
+
+		app3 := fragment[2]
+		assert.Equal(t, "kube.monitoring.app3.**", app3.Tag)
+
+		assert.True(t, strings.Index(fragment.String(), "{") < 0)
+		assert.True(t, strings.Index(fragment.String(), "}") < 0)
+	}
+}
+
+func TestNestedTagsExpandOk(t *testing.T) {
+	var s = `
+	<match **>
+		@type relabel
+		@label @test
+	</match>
+
+	<label @test>
+	  <match kube.monitoring.{app1, app2}.** kube.monitoring.app3.**>
+		@type null
+	  </match>
+	</label>
+	`
+
+	fragment, err := fluentd.ParseString(s)
+	assert.Nil(t, err)
+
+	fmt.Printf("Original:\n%s", fragment)
+
+	ctx := &ProcessorContext{
+		Namepsace:         "monitoring",
+		GenerationContext: &GenerationContext{},
+	}
+	fragment, err = Process(fragment, ctx, DefaultProcessors()...)
+	assert.Nil(t, err)
+	assert.Equal(t, len(fragment), 2)
+	assert.Equal(t, len(fragment[1].Nested), 3)
+	fmt.Printf("Processed:\n%s", fragment)
+
+	app1 := fragment[1].Nested[0]
+	assert.Equal(t, "kube.monitoring.app1.**", app1.Tag)
+
+	app2 := fragment[1].Nested[1]
+	assert.Equal(t, "kube.monitoring.app2.**", app2.Tag)
+
+	app3 := fragment[1].Nested[2]
+	assert.Equal(t, "kube.monitoring.app3.**", app3.Tag)
+
+	assert.True(t, strings.Index(fragment.String(), "{") < 0)
+	assert.True(t, strings.Index(fragment.String(), "}") < 0)
+}
+
+func TestTagsExpandBadConfig(t *testing.T) {
+
+	ctx := &ProcessorContext{
+		Namepsace: "monitoring",
+	}
+
+	list := []string{
+		`<match kube.monitoring.#{ENV_VAR}.**>
+          @type null
+		 </match>`,
+		`<match kube.monitoring.{app1.**>
+		  @type null
+		</match>`,
+		`<match kube.monitoring.app2}.**>
+		  @type null
+		</match>`,
+	}
+
+	for _, s := range list {
+		fragment, err := fluentd.ParseString(s)
+		assert.Nil(t, err)
+
+		_, err = Process(fragment, ctx, &expandTagsState{})
+		assert.NotNil(t, err)
+	}
+}

--- a/config-reloader/processors/expand_tags_test.go
+++ b/config-reloader/processors/expand_tags_test.go
@@ -29,6 +29,7 @@ func TestTagsExpandOk(t *testing.T) {
 		ctx := &ProcessorContext{
 			Namepsace:         "monitoring",
 			GenerationContext: &GenerationContext{},
+			AllowTagExpansion: true,
 		}
 		fragment, err = Process(fragment, ctx, &expandTagsState{})
 		assert.Nil(t, err)
@@ -71,6 +72,7 @@ func TestNestedTagsExpandOk(t *testing.T) {
 	ctx := &ProcessorContext{
 		Namepsace:         "monitoring",
 		GenerationContext: &GenerationContext{},
+		AllowTagExpansion: true,
 	}
 	fragment, err = Process(fragment, ctx, DefaultProcessors()...)
 	assert.Nil(t, err)
@@ -94,7 +96,8 @@ func TestNestedTagsExpandOk(t *testing.T) {
 func TestTagsExpandBadConfig(t *testing.T) {
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namepsace:         "monitoring",
+		AllowTagExpansion: true,
 	}
 
 	list := []string{

--- a/config-reloader/processors/labels_test.go
+++ b/config-reloader/processors/labels_test.go
@@ -194,6 +194,7 @@ func TestLabelWithLabelsAndElse(t *testing.T) {
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
+		AllowTagExpansion: true,
 	}
 
 	fragment, err = Process(fragment, ctx, DefaultProcessors()...)

--- a/config-reloader/processors/processor.go
+++ b/config-reloader/processors/processor.go
@@ -192,6 +192,7 @@ func augmentTag(orig string) string {
 func DefaultProcessors() []FragmentProcessor {
 	return []FragmentProcessor{
 		&expandPluginsState{},
+		&expandTagsState{},
 		&expandThisnsMacroState{},
 		&fixDestinations{},
 		&expandLabelsMacroState{},

--- a/config-reloader/processors/processor.go
+++ b/config-reloader/processors/processor.go
@@ -44,6 +44,7 @@ type ProcessorContext struct {
 	MiniContainers    []*datasource.MiniContainer
 	KubeletRoot       string
 	GenerationContext *GenerationContext
+	AllowTagExpansion bool
 }
 
 type BaseProcessorState struct {

--- a/config-reloader/processors/relabel_test.go
+++ b/config-reloader/processors/relabel_test.go
@@ -148,6 +148,7 @@ func TestLabelWithLabelsAndRelabelsAndElse(t *testing.T) {
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
+		AllowTagExpansion: true,
 	}
 
 	fragment, err = Process(fragment, ctx, DefaultProcessors()...)
@@ -183,6 +184,7 @@ func TestNastyRegex(t *testing.T) {
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
+		AllowTagExpansion: true,
 	}
 
 	_, err = Process(fragment, ctx, DefaultProcessors()...)

--- a/config-reloader/processors/thisns.go
+++ b/config-reloader/processors/thisns.go
@@ -4,7 +4,6 @@
 package processors
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -41,10 +40,6 @@ func (p *expandThisnsMacroState) Process(input fluentd.Fragment) (fluentd.Fragme
 			d.Tag = goodPrefix + d.Tag[len(macroThisns):]
 			ctx.GenerationContext.augmentTag(d)
 			return nil
-		}
-
-		if strings.Index(d.Tag, "{") >= 0 {
-			return errors.New("Cannot process {} in the tag yet")
 		}
 
 		if strings.HasPrefix(d.Tag, macroLabels) {

--- a/config-reloader/processors/thisns_test.go
+++ b/config-reloader/processors/thisns_test.go
@@ -89,9 +89,6 @@ func TestThisnsExpandBadConfig(t *testing.T) {
 		`<match>
 	       @type null
 		 </match>`,
-		`<match a.{b,c}>
-	       @type null
-	     </match>`,
 	}
 
 	for _, s := range list {

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -108,6 +108,9 @@ spec:
           - --namespaces
           - "{{ . }}"
           {{- end }}
+          {{- if .Values.allowTagExpansion }}
+          - --allow-tag-expansion
+          {{- end }}
           volumeMounts:
           - name: fluentconf
             mountPath: /fluentd/etc

--- a/log-router/values.yaml
+++ b/log-router/values.yaml
@@ -81,3 +81,5 @@ updateStrategy: {}
 #  scheduler.alpha.kubernetes.io/tolerations: '[{"key": "example", "value": "foo"}]'
 
 prometheusEnabled: false
+
+allowTagExpansion: false


### PR DESCRIPTION
A valid Fluentd configuration file allows to specify match patterns of
the type "k.{a,b}.\*\*" that are expanded to match both tag "k.a.\*\*" and
tag "k.b.\*\*" and processed with the same set of rules. Furthermore,
several tags can be listed in the match pattern separated by a space to
provide an expression that will match any of the tags. Supporting such
tag expansion allows to consistently reduce the number of equivalent
rules that need to be provided in the configuration file, especially
for complex systems that contain several log parsing pipelines. Finally,
support for such feature also reduces the risk for configuration errors
typical of the copy-paste pattern that needs to be adopted when such
expansion is performed by the user.

By adding this new processor to the default processing pipeline, the config
reloader can emulate the behavior of Fluentd and perform tag expansion
programmatically, in the early stages of the pipeline. Therefore, the
other processors will receive in input a configuration equivalent to the
one specified by the user, but in the expected expanded format. However,
the user will be able to take advantage of the tag expansion feature to
reduce the number of rules that need to be provided and delegate the
copy-paste to the config reloader, thus avoiding potential errors.

This processor supports both the "{a,b}" pattern and the "a b" pattern.
As an example, this match pattern
```
<match kube.test.{x,y,z}.** kube.test.p.{a, b}.**>
```
will be expanded in the following separate match patterns
```
<match kube.test.x.**>
<match kube.test.y.**>
<match kube.test.z.**>
<match kube.test.p.a.**>
<match kube.test.p.b.**>
```
and the contents of the original match statement will be cloned in each
of the expanded match statements.
Tag expansion is performed both in match directives and in filter directives.

Related issue: vmware/kube-fluentd-operator#4