### PR TITLE
Add new processor to allow controlled tag rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,9 +365,9 @@ kube-fluentd-operator will insert the content of the `plugin` directive in the `
 
 ### Retagging based on log contents (since v1.12.0)
 
-Sometimes you might need to split a single log stream to perform different processing based on the contents of one of the fields. To achieve this you can use the `retag` plugin that allows to specify a set of rules that match regular expressions against the specified fields. If one of the rules matches, the log is re-emitted with the new specified tag.
+Sometimes you might need to split a single log stream to perform different processing based on the contents of one of the fields. To achieve this you can use the `retag` plugin that allows to specify a set of rules that match regular expressions against the specified fields. If one of the rules matches, the log is re-emitted with a new namespace-unique tag based on the specified tag.
 
-The tag is specified using the `$tag` macro, and logs that are emitted by this plugin can be consequently filtered and processed by using the same `$tag` macro when specifiying the tag:
+Logs that are emitted by this plugin can be consequently filtered and processed by using the `$tag` macro when specifiying the tag:
 
 ```xml
 <match $labels(app=apache)>
@@ -375,17 +375,17 @@ The tag is specified using the `$tag` macro, and logs that are emitted by this p
   <rule>
     key message
     pattern /^(ERROR) .*$/
-    tag $tag(notifications.$1) # refer to a capturing group using $number
+    tag notifications.$1 # refer to a capturing group using $number
   </rule>
   <rule>
     key message
     pattern /^(FATAL) .*$/
-    tag $tag(notifications.$1)
+    tag notifications.$1
   </rule>
   <rule>
     key message
     pattern /^(ERROR)|(FATAL) .*$/
-    tag $tag(notifications.other)
+    tag notifications.other
     invert true # rewrite tag when unmatch pattern
   </rule>
 </match>
@@ -935,13 +935,13 @@ The `retag` plugin allows to split a log stream based on whether the contents of
   <rule>
     key message
     pattern ^ERR
-    tag $tag(notifications.error)
+    tag notifications.error
   </rule>
   <rule>
     key message
     pattern ^ERR
     invert true
-    tag $tag(notifications.other)
+    tag notifications.other
   </rule>
 </match>
 

--- a/config-reloader/processors/processor.go
+++ b/config-reloader/processors/processor.go
@@ -197,6 +197,7 @@ func DefaultProcessors() []FragmentProcessor {
 		&expandThisnsMacroState{},
 		&fixDestinations{},
 		&expandLabelsMacroState{},
+		&uniqueRewriteTagState{},
 		&rewriteLabelsState{},
 		&mountedFileState{},
 		&shareLogsState{},

--- a/config-reloader/processors/thisns.go
+++ b/config-reloader/processors/thisns.go
@@ -42,8 +42,8 @@ func (p *expandThisnsMacroState) Process(input fluentd.Fragment) (fluentd.Fragme
 			return nil
 		}
 
-		if strings.HasPrefix(d.Tag, macroLabels) {
-			// Let the labels processor handle this
+		if strings.HasPrefix(d.Tag, macroLabels) || strings.HasPrefix(d.Tag, macroUniqueTag) {
+			// Let other processors handle this
 			return nil
 		}
 

--- a/config-reloader/processors/unique_rewrite_tag.go
+++ b/config-reloader/processors/unique_rewrite_tag.go
@@ -19,7 +19,7 @@ type uniqueRewriteTagState struct {
 func (p *uniqueRewriteTagState) Process(input fluentd.Fragment) (fluentd.Fragment, error) {
 	adaptUniqueRewriteTagPlugin := func(d *fluentd.Directive, ctx *ProcessorContext) error {
 
-		if d.Name != "match" || d.Type() != "unique_rewrite_tag" {
+		if d.Name != "match" || d.Type() != "retag" {
 			return nil
 		}
 
@@ -30,11 +30,11 @@ func (p *uniqueRewriteTagState) Process(input fluentd.Fragment) (fluentd.Fragmen
 
 			tagParam := rule.Param("tag")
 			if !strings.HasPrefix(tagParam, macroUniqueTag) || !strings.HasSuffix(tagParam, ")") {
-				return fmt.Errorf("unique_rewrite_tag plugin requires each rule to have a tag parameter specifying the tag inside the $tag() macro")
+				return fmt.Errorf("retag plugin requires each rule to have a tag parameter specifying the tag inside the $tag() macro")
 			}
 
 			if strings.Index(tagParam, "${tag_parts[") >= 0 || strings.Index(tagParam, "__TAG_PARTS[") >= 0 {
-				return fmt.Errorf("unique_rewrite_tag plugin does not yet support the ${tag_parts[n]} and __TAG_PARTS[n]__ placeholders")
+				return fmt.Errorf("retag plugin does not yet support the ${tag_parts[n]} and __TAG_PARTS[n]__ placeholders")
 			}
 
 			targetTag := tagParam[len(macroUniqueTag)+1 : len(tagParam)-1]
@@ -60,7 +60,7 @@ func (p *uniqueRewriteTagState) Process(input fluentd.Fragment) (fluentd.Fragmen
 		}
 
 		if !strings.HasSuffix(d.Tag, ")") {
-			return fmt.Errorf("Malformed tag. To match output from the unique_rewrite_tag plugin the tag must be placed inside the $tag() macro")
+			return fmt.Errorf("Malformed tag. To match output from the retag plugin the tag must be placed inside the $tag() macro")
 		}
 
 		targetTag := d.Tag[len(macroUniqueTag)+1 : len(d.Tag)-1]

--- a/config-reloader/processors/unique_rewrite_tag_test.go
+++ b/config-reloader/processors/unique_rewrite_tag_test.go
@@ -17,12 +17,12 @@ func TestTagsRewrittenOk(t *testing.T) {
       <rule>
         key message
         pattern ^ERROR
-        tag $tag(notifications.error)
+        tag notifications.error
       </rule>
       <rule>
         key message
         pattern ^FATAL
-        tag $tag(notifications.fatal)
+        tag notifications.fatal
       </rule>
     </match>
 
@@ -70,7 +70,7 @@ func TestTagsRewrittenOk(t *testing.T) {
 
 	match := fragment[3]
 
-	assert.Equal(t, strings.Split(filter1.Tag, ".")[0], strings.Split(match.Tag, ".")[0])
+	assert.Equal(t, strings.Split(filter1.Tag, ".error")[0], strings.Split(match.Tag, ".**")[0])
 	assert.True(t, strings.Index(match.Tag, macroUniqueTag) < 0)
 }
 
@@ -88,18 +88,25 @@ func TestRewriteTagsBadConfig(t *testing.T) {
 		  @type rewrite_tag_filter
 		  <rule>
 		    key message
-		      pattern ^ERROR
-		      tag $tag(notifications.error)
-			</rule>
-		 </match>`,
+			pattern ^ERROR
+			tag notifications.error
+		  </rule>
+		</match>`,
 		`<match kube.monitoring.**>
 		  @type retag
 		  <rule>
 		    key message
 		    pattern ^ERROR
-		    tag notifications.error
-		   </rule>
-		 </match>`,
+		  </rule>
+		</match>`,
+		`<match kube.monitoring.**>
+		  @type retag
+		  <rule>
+		    key message
+			pattern ^ERROR
+			tag notifications.${tag_parts[1]}
+		  </rule>
+		</match>`,
 	}
 
 	for _, s := range list {

--- a/config-reloader/processors/unique_rewrite_tag_test.go
+++ b/config-reloader/processors/unique_rewrite_tag_test.go
@@ -13,7 +13,7 @@ import (
 func TestTagsRewrittenOk(t *testing.T) {
 	var s = `
 	<match kube.monitoring.**>
-      @type unique_rewrite_tag
+      @type retag
       <rule>
         key message
         pattern ^ERROR
@@ -93,7 +93,7 @@ func TestRewriteTagsBadConfig(t *testing.T) {
 			</rule>
 		 </match>`,
 		`<match kube.monitoring.**>
-		  @type unique_rewrite_tag
+		  @type retag
 		  <rule>
 		    key message
 		    pattern ^ERROR

--- a/config-reloader/processors/unique_rewrite_tag_test.go
+++ b/config-reloader/processors/unique_rewrite_tag_test.go
@@ -1,0 +1,112 @@
+package processors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/vmware/kube-fluentd-operator/config-reloader/fluentd"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagsRewrittenOk(t *testing.T) {
+	var s = `
+	<match kube.monitoring.**>
+      @type unique_rewrite_tag
+      <rule>
+        key message
+        pattern ^ERROR
+        tag $tag(notifications.error)
+      </rule>
+      <rule>
+        key message
+        pattern ^FATAL
+        tag $tag(notifications.fatal)
+      </rule>
+    </match>
+
+    <filter $tag(notifications.error)>
+      @type null
+    </filter>
+
+    <filter $tag(notifications.fatal)>
+	  @type null
+    </filter>
+
+    <match $tag(notifications.**)>
+	  @type null
+    </match>
+	`
+
+	fragment, err := fluentd.ParseString(s)
+	assert.Nil(t, err)
+
+	fmt.Printf("Original:\n%s", fragment)
+
+	ctx := &ProcessorContext{
+		Namepsace:         "monitoring",
+		GenerationContext: &GenerationContext{},
+	}
+	fragment, err = Process(fragment, ctx, &uniqueRewriteTagState{})
+	assert.Nil(t, err)
+	fmt.Printf("Processed:\n%s", fragment)
+
+	rewritePlugin := fragment[0]
+	assert.Equal(t, "rewrite_tag_filter", rewritePlugin.Param("@type"))
+
+	rule1 := rewritePlugin.Nested[0]
+	rule2 := rewritePlugin.Nested[1]
+
+	filter1 := fragment[1]
+	filter2 := fragment[2]
+
+	assert.Equal(t, rule1.Param("tag"), filter1.Tag)
+	assert.Equal(t, rule2.Param("tag"), filter2.Tag)
+	assert.True(t, strings.Index(filter1.Tag, macroUniqueTag) < 0)
+	assert.True(t, strings.Index(filter2.Tag, macroUniqueTag) < 0)
+	assert.NotEqual(t, strings.Split(filter1.Tag, ".")[0], "notifications")
+	assert.NotEqual(t, strings.Split(filter2.Tag, ".")[0], "notifications")
+
+	match := fragment[3]
+
+	assert.Equal(t, strings.Split(filter1.Tag, ".")[0], strings.Split(match.Tag, ".")[0])
+	assert.True(t, strings.Index(match.Tag, macroUniqueTag) < 0)
+}
+
+func TestRewriteTagsBadConfig(t *testing.T) {
+
+	ctx := &ProcessorContext{
+		Namepsace: "monitoring",
+		GenerationContext: &GenerationContext{
+			ReferencedBridges: map[string]bool{},
+		},
+	}
+
+	list := []string{
+		`<match kube.monitoring.**>
+		  @type rewrite_tag_filter
+		  <rule>
+		    key message
+		      pattern ^ERROR
+		      tag $tag(notifications.error)
+			</rule>
+		 </match>`,
+		`<match kube.monitoring.**>
+		  @type unique_rewrite_tag
+		  <rule>
+		    key message
+		    pattern ^ERROR
+		    tag notifications.error
+		   </rule>
+		 </match>`,
+	}
+
+	for _, s := range list {
+		fragment, err := fluentd.ParseString(s)
+		assert.Nil(t, err)
+
+		_, err = Process(fragment, ctx, DefaultProcessors()...)
+		assert.NotNil(t, err)
+	}
+}


### PR DESCRIPTION
The plugin "rewrite_tag_filter" provided alongside Fluentd allows conditional
tag rewriting to perform different processing pipelines based on log contents.
This same behavior is not achievable without it unless all logs are copied
to different output labels and then filtered through the grep plugin which
however introduces considerable overhead.
Clearly, however, the usage of this plugin needs to be constrained as it
allows to break the namespace isolation enforced by the config-reloader.

This enhancement introduces a new processor that allows to specify a new
virtual output plugin, "unique_rewrite_tag", which behaves exactly as the
"rewrite_tag_filter" (and has the same syntax and supported options), but
requires the new tag to be specified using the macro $tag(new_tag).
In order to match logs that are emitted by such output plugin it is
sufficient to specify the same macro in match and filter directives.
The processor will internally handle such configuration and ensure
that the rewritten tags are unique with respect to other namespaces and
thus will avoid breaking isolation while allowing conditional rewriting.

As an example, it might be necessary to divide logs based on the severity
which is the first word printed in the message from the app, process them
differently and then send them to the same output. This can be achieved as
follows:

```
<match kube.ns.**>
  @type unique_rewrite_tag
  <rule>
    key message
    pattern ^ERROR
    tag $tag(notifications.error)
  </rule>
  <rule>
    key message
    pattern ^FATAL
    tag $tag(notifications.fatal)
  </rule>
</match>

<filter $tag(notifications.fatal)>
  ...(perform some extra processing)
</filter>

<filter $tag(notifications.error)>
  ...(perform different processing)
</filter>

<match $tag(notifications.**)>
  ...(common output plugin)
</match>
```