### PR TITLE
Introduce a more efficient event-triggered reload system

### DIFF
--- a/config-reloader/controller/updater.go
+++ b/config-reloader/controller/updater.go
@@ -1,0 +1,36 @@
+package controller
+
+import (
+	"time"
+)
+
+// Updater provides a means to notify through a channel that an update is necessary
+type Updater interface {
+	GetUpdateChannel() <-chan time.Time
+}
+
+// FixedTimeUpdater is an Updater that delivers a notification after a fixed amount of time
+type FixedTimeUpdater struct {
+	interval time.Duration
+}
+
+func NewFixedTimeUpdater(seconds int) *FixedTimeUpdater {
+	return &FixedTimeUpdater{interval: time.Duration(seconds) * time.Second}
+}
+
+func (f *FixedTimeUpdater) GetUpdateChannel() <-chan time.Time {
+	return time.After(f.interval)
+}
+
+// OnDemandUpdater is an Updater that delivers notifications on demand through a shared channel
+type OnDemandUpdater struct {
+	channel chan time.Time
+}
+
+func NewOnDemandUpdater(channel chan time.Time) *OnDemandUpdater {
+	return &OnDemandUpdater{channel: channel}
+}
+
+func (o *OnDemandUpdater) GetUpdateChannel() <-chan time.Time {
+	return o.channel
+}


### PR DESCRIPTION
Fluentd configurations are usually required to be reloaded as soon as
possible after they have been deployed in the ConfigMap as the corresponding
applications might start logging right away and until such configurations
are deployed, all logs might not get parsed correctly.

*kube-fluentd-operator* can be configured to reload and calculate new configs
after a given interval regardless of changes that have happened in the
cluster. However, this system can become inefficient, especially for large
clusters with many configurations to load, parse and rewrite. An interval
which is too small leads to configurations being available almost instantly
after the ConfigMap is deployed, but when no changes to such configurations
happen for a long time, it leads to a lot of useless recalculations. On the
other hand, a larger interval can reduce the amount of useless processing at
the expense of the time that it might take for configurations to get to
Fluentd after being deployed in the ConfigMap.

This enhancement introduces a new system to react to changes in the K8S
cluster only when changes happen, but as soon as they happen. The config-
reloader now registers with the Kubernetes API-Server and gets notified
when ConfigMaps are changed in the cluster. Thanks to this, if no new
configurations are deployed for a long period of time, the reload process
is never started, but as soon as a ConfigMap containing Fluentd configs
is created, modified or deleted, *kube-fluentd-operator* is able to
instantly react and run the main loop to analyze and create the configs.

This enhancement is able to consistently reduce the amount of useless
work performed by the config-reloader, without impacting its readiness
to react to new changes.