### PR TITLE
Fix slow CRI-O log parsing

### DIFF
--- a/config-reloader/templates/kubernetes.conf
+++ b/config-reloader/templates/kubernetes.conf
@@ -11,7 +11,7 @@
   <parse>
     @type multiline
     # cri-o
-    format1 /(?<partials>.+ (stdout|stderr) P .+\n)*/
+    format1 /^(?<partials>.+ (stdout|stderr) P .+\n)*/
     format2 /(?<time>.+) (?<stream>stdout|stderr) F (?<log>.*)/
     # docker
     format3 /|(?<json>{.*})/


### PR DESCRIPTION
Ruby regex implementation is extremely slow without an anchor.