### PR TITLE
Fix slow CRI-O log parsing

### DIFF
--- a/config-reloader/templates/kubernetes.conf
+++ b/config-reloader/templates/kubernetes.conf
@@ -11,8 +11,8 @@
   <parse>
     @type multiline
     # cri-o
-    format1 /(?<partials>.+ (stdout|stderr) P .+\n)*/
-    format2 /(?<time>.+) (?<stream>stdout|stderr) F (?<log>.*)/
+    format1 /^(?<partials>([^\n]+ (stdout|stderr) P [^\n]+\n)*)/
+    format2 /(?<time>[^\n]+) (?<stream>stdout|stderr) F (?<log>[^\n]*)/
     # docker
     format3 /|(?<json>{.*})/
     time_format %Y-%m-%dT%H:%M:%S.%N%:z


### PR DESCRIPTION
Ruby regex implementation is extremely slow without an anchor.