### PR TITLE
Fix namespace fluentd status annotation update

### DIFF
--- a/config-reloader/generator/generator.go
+++ b/config-reloader/generator/generator.go
@@ -157,15 +157,14 @@ func (g *Generator) renderMainFile(mainFile string, outputDir string, dest strin
 
 		prepConfig, err := extractPrepConfig(nsConf.Name, prepareConfigs)
 
-		if err != nil {
-			configHash = util.Hash("ERROR", err.Error())
-		} else {
+		if err == nil {
 			// render config
 			renderedConfig, _, err = g.makeNamespaceConfiguration(nsConf, genCtx, onlyProcess)
 			configHash = util.Hash("", renderedConfig+prepConfig)
 		}
 
 		if err != nil {
+			configHash = util.Hash("ERROR", err.Error())
 			logrus.Infof("Configuration for namespace %s cannot be validated: %+v", nsConf.Name, err)
 			if nsConf.PreviousConfigHash != configHash {
 				g.updateStatus(nsConf.Name, err.Error())


### PR DESCRIPTION
This fix addresses the case in which a processor returns an error during
the execution of the processing phase. If the namespace was previously
empty (non-configured) and no new prep configs have been added, the
previous hash and new hash match and therefore the error message is not
patched on the namespace annotation, making it hard for a user to
understand why the new configuration is not being deployed.