### PR TITLE
Fix $label processor ignoring errors and not accepting "/"

### DIFF
--- a/config-reloader/processors/detect_exceptions_test.go
+++ b/config-reloader/processors/detect_exceptions_test.go
@@ -86,7 +86,7 @@ func TestWithoutExceptions(t *testing.T) {
 	fmt.Printf("Processed:\n%s\n", processed)
 
 	last := processed[len(processed)-1]
-	assert.Equal(t, "kube.monitoring.*.*._labels.*", last.Tag)
+	assert.Equal(t, "kube.monitoring.**", last.Tag)
 }
 
 func TestWithExceptions(t *testing.T) {
@@ -128,7 +128,7 @@ func TestWithExceptions(t *testing.T) {
 	fmt.Printf("Processed:\n%s\n", processed)
 
 	last := processed[len(processed)-1]
-	assert.Equal(t, "kube.monitoring.*.*._labels.*.* _proc.kube.monitoring.*.*._labels.*.*", last.Tag)
+	assert.Equal(t, "kube.monitoring.** _proc.kube.monitoring.**", last.Tag)
 
 	detExc := processed[len(processed)-2]
 	assert.Equal(t, "container_info", detExc.Param("stream"))

--- a/config-reloader/processors/labels.go
+++ b/config-reloader/processors/labels.go
@@ -33,7 +33,7 @@ var reSafe = regexp.MustCompile("[.-]|^$")
 // an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is
 // '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
 
-var reValidLabelName = regexp.MustCompile("^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$")
+var reValidLabelName = regexp.MustCompile("^([A-Za-z0-9][-A-Za-z0-9\\/_.]*)?[A-Za-z0-9]$")
 var reValidLabelValue = regexp.MustCompile("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")
 
 var fns = template.FuncMap{
@@ -176,7 +176,10 @@ func (p *expandLabelsMacroState) Process(input fluentd.Fragment) (fluentd.Fragme
 
 		return nil
 	}
-	applyRecursivelyInPlace(input, p.Context, collectLabels)
+	e := applyRecursivelyInPlace(input, p.Context, collectLabels)
+	if e != nil {
+		return nil, e
+	}
 	if len(allReferencedLabels) == 0 {
 		return input, nil
 	}

--- a/config-reloader/processors/labels.go
+++ b/config-reloader/processors/labels.go
@@ -68,9 +68,6 @@ var retagTemplate = template.Must(template.New("retagTemplate").Funcs(fns).Parse
 `))
 
 func parseTagToLabels(tag string) (map[string]string, error) {
-	if !strings.HasPrefix(tag, macroLabels) {
-		return nil, nil
-	}
 
 	if !strings.HasPrefix(tag, macroLabels+"(") &&
 		!strings.HasSuffix(tag, ")") {
@@ -161,7 +158,7 @@ func (p *expandLabelsMacroState) Process(input fluentd.Fragment) (fluentd.Fragme
 			return nil
 		}
 
-		if d.Tag == "" {
+		if !strings.HasPrefix(d.Tag, macroLabels) {
 			return nil
 		}
 
@@ -192,13 +189,13 @@ func (p *expandLabelsMacroState) Process(input fluentd.Fragment) (fluentd.Fragme
 			return nil
 		}
 
-		if d.Tag == "" {
+		if !strings.HasPrefix(d.Tag, macroLabels) {
 			return nil
 		}
 
 		labelNames, err := parseTagToLabels(d.Tag)
 		if err != nil {
-			// nothing to replace, it was not a $labels macro
+			// should never happen as the error should be caught beforehand
 			return nil
 		}
 

--- a/config-reloader/processors/labels_test.go
+++ b/config-reloader/processors/labels_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestLabelsParseOk(t *testing.T) {
 	inputs := map[string]map[string]string{
-		"**.hello.world":                nil,
 		"$labels(a=b,,,)":               {"a": "b"},
 		"$labels(a=1, b=2)":             {"a": "1", "b": "2"},
 		"$labels(x=y,b=1)":              {"b": "1", "x": "y"},


### PR DESCRIPTION
This fix addresses two errors in the processor that manages the `$label`
macro.

The first error occurs when a bad label is used in the configurations.
The processor detects the bad label but fails to report the error and
stop the processing, therefore the unmodified tag containing the $label
macro is delivered to the fluentd config.

The second issue is the failure of the processor to accept as valid
labels containing the `/` character, which is however not only valid,
but encouraged for example by [helm as a best practice for the
standard labels](https://helm.sh/docs/topics/chart_best_practices/labels/).

Signed-off-by: Tommaso Pozzetti <tommypozzetti@hotmail.it>