### PR TITLE
Change daemonset to apps/v1 and fix validity

### DIFF
--- a/log-router/Chart.yaml
+++ b/log-router/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 description: Distribution of Fluentd as K8S daemonset
 name: log-router
-version: 0.3.2
+version: 0.3.3
 home: https://github.com/vmware/kube-fluentd-operator
 sources:
   - https://github.com/vmware/kube-fluentd-operator

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -3,7 +3,7 @@ Copyright © 2018 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: BSD-2-Clause
 */}}
 {{- $root := . -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "fluentd-router.fullname" . }}
@@ -13,6 +13,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fluentd-router.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Pretty trivial but I try to keep up with Kubernetes deprecations where possible.

Remove use of deprecated DaemonSet API:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/