### PR TITLE
Remove deprecated config/plugin from config-reloader templates.

### DIFF
--- a/config-reloader/templates/kubernetes-postprocess.conf
+++ b/config-reloader/templates/kubernetes-postprocess.conf
@@ -1,12 +1,3 @@
-# Query the API for extra metadata.
-<filter kubernetes.**>
-  @type kubernetes_metadata
-  # If the logs begin with '{' and end with '}' then it's JSON so merge
-  # the JSON log field into the log event
-  merge_json_log true
-  preserve_json_log true
-</filter>
-
 # rewrite_tag_filter does not support nested fields like
 # kubernetes.container_name, so this exists to flatten the fields
 # so we can use them in our rewrite_tag_filter
@@ -49,14 +40,3 @@
   remove_keys kubernetes_namespace_container_name
 </filter>
 
-# Parse logs in the kube-system namespace using the kubernetes formatter.
-<filter kube.kube-system.**>
-  @type parser
-  reserve_data true
-  key_name log
-  emit_invalid_record_to_error false
-  <parse>
-    @type kubernetes
-    time_format %FT%T%:z
-  </parse>
-</filter>


### PR DESCRIPTION
Signed-off-by: Raja Sekhar <rajasekhar@vmware.com>

This addresses https://github.com/vmware/kube-fluentd-operator/issues/108
Please have a look.