### PR TITLE
Cleanup unused namespace configuration files

### DIFF
--- a/config-reloader/controller/controller.go
+++ b/config-reloader/controller/controller.go
@@ -107,5 +107,7 @@ func (c *Controller) RunOnce() error {
 		c.Reloader.ReloadConfiguration()
 	}
 
+	c.Generator.CleanupUnusedFiles(c.OutputDir, configHashes)
+
 	return nil
 }


### PR DESCRIPTION
The config files created by the config-reloader are never deleted.
This practically means that in environments with several namespaces
and/or a lot of creation/deletion of namespaces, a big number of files
of type `ns-<namespace>.conf` can end up populating the config
directory.

This fix adds a cleanup call at the end of each loop that verifies
whether any file belongs to namespaces that are no longer existent
and deletes them. This fix also deletes any configuration file
of namespaces that are still existent but have no specified fluentd
configuration.