### PR TITLE
Make the admin namespace configurable

### DIFF
--- a/config-reloader/config/config.go
+++ b/config-reloader/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	Namespaces             []string
 	PrometheusEnabled      bool
 	AllowTagExpansion      bool
+	AdminNamespace         string
 	// parsed or processed/cached fields
 	level               logrus.Level
 	ParsedMetaValues    map[string]string
@@ -66,6 +67,7 @@ var defaultConfig = &Config{
 	IntervalSeconds:      60,
 	ID:                   "default",
 	PrometheusEnabled:    false,
+	AdminNamespace:       "kube-system",
 }
 
 var reValidID = regexp.MustCompile("([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]")
@@ -217,6 +219,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("label-selector", "Label selector in the k=v,k2=v2 format (used only with --datasource=multimap)").StringVar(&cfg.LabelSelector)
 
 	app.Flag("allow-tag-expansion", "Allow specifying tags in the format 'k.{a,b}.** k.c.**' (default: false)").BoolVar(&cfg.AllowTagExpansion)
+
+	app.Flag("admin-namespace", "Configurations defined in this namespace are copied as is, without further processing. Virtual plugins can also be defined in this namespace").Default(defaultConfig.AdminNamespace).StringVar(&cfg.AdminNamespace)
 	_, err := app.Parse(args)
 
 	if err != nil {

--- a/config-reloader/processors/extract_plugins.go
+++ b/config-reloader/processors/extract_plugins.go
@@ -8,7 +8,7 @@ const (
 	dirPlugin = "plugin"
 )
 
-// ExtractPlugins looks at the top-level directives in the kube-system, deletes all <plugin>
+// ExtractPlugins looks at the top-level directives in the admin namespace, deletes all <plugin>
 // and stores the found plugin definitions under GenerationContext.Plugins map keyed by the plugin directive's path
 func ExtractPlugins(g *GenerationContext, input fluentd.Fragment) fluentd.Fragment {
 	plugins := map[string]*fluentd.Directive{}

--- a/config-reloader/templates/fluent.conf
+++ b/config-reloader/templates/fluent.conf
@@ -49,10 +49,10 @@
 
 
 #################
-# Generated based on annotated kube-system namespace
+# Generated based on annotated admin namespace
 #################
-{{if .KubeSystem -}}
-@include kube-system.conf
+{{if .AdminNamespace -}}
+@include admin-ns.conf
 {{- end }}
 #################
 

--- a/log-router/templates/daemonset.yaml
+++ b/log-router/templates/daemonset.yaml
@@ -116,6 +116,9 @@ spec:
           {{- if .Values.allowTagExpansion }}
           - --allow-tag-expansion
           {{- end }}
+          {{- if .Values.adminNamespace }}
+          - --admin-namespace={{ .Values.adminNamespace }}
+          {{- end }}
           volumeMounts:
           - name: fluentconf
             mountPath: /fluentd/etc

--- a/log-router/values.yaml
+++ b/log-router/values.yaml
@@ -85,3 +85,8 @@ updateStrategy: {}
 prometheusEnabled: false
 
 allowTagExpansion: false
+
+# Change the following value to define a different namespace that is treated as admin
+# namespace, i.e. its configs are not validated or processed and virtual plugins can be
+# defined to be used in all other namespaces.
+adminNamespace: "kube-system"


### PR DESCRIPTION
The config-reloader assumes that the admin namespace in which fluentd configs get defined without validation and/or processing and in which virtual plugins are defined is the `kube-system` namespace. While this assumption is reasonable in general, there might be instances in which the logging infrastructure is installed in a dedicated namespace and it would be cleaner and more manageable to be able to install virtual plugins and global fluentd configs in that same namespace. Furthermore, it might be the case that the kube-system namespace already contains a number of infrastructural components that would benefit from having fluentd configurations defined using the config-reloader and that would also benefit from all the processing that the config-reloader can offer on those configs, such as the "$labels" macro and so on.

This PR adds the possibility of configuring which is the namespace that is used as an admin namespace through a flag of config-reloader which defaults to `kube-system` for backwards compatibility. This way, cluster admins which would benefit from defining global fluentd configs and virtual plugins in a specific dedicated namespace can choose to do so.