### PR TITLE
Update output plugin docs; Signed-off-by: Shazad Brohi <sbrohi@vmware.com>

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,11 @@ Sometimes you only have a few valid options for log sinks: a dedicated S3 bucket
 
 ```xml
 admin-ns.conf:
+<match systemd.** docker kube.kube-system.** k8s.**>
+  @type loggly
+  loggly_url https://logs-01.loggly.com/inputs/TOKEN/tag/fluentd
+</match>
+
 <plugin test>
   @type s3
   aws_key_id  YOUR_AWS_KEY_ID
@@ -345,6 +350,8 @@ admin-ns.conf:
   loggly_url https://logs-01.loggly.com/inputs/TOKEN/tag/fluentd
 </plugin>
 ```
+
+In the above example configuration for the `admin` namespace, we first have a `match` directive which will send all `systemd`, `docker`, `kube-system`, and kubernetes control plane logs to our loggly endpoint. Below the match directive are then the 2 plugin directives "test" and "staging" that can be re-used in namespace fluentd config maps. 
 
 A namespace can refer to the `staging` and `test` plugins oblivious to the fact where exactly the logs end up:
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Sometimes you only have a few valid options for log sinks: a dedicated S3 bucket
 admin-ns.conf:
 <match systemd.** docker kube.kube-system.** k8s.**>
   @type loggly
-  loggly_url https://logs-01.loggly.com/inputs/TOKEN/tag/fluentd
+  loggly_url https://logs-01.loggly.com/inputs/<TOKEN>/tag/fluentd
 </match>
 
 <plugin test>
@@ -347,7 +347,7 @@ admin-ns.conf:
 
 <plugin staging>
   @type loggly
-  loggly_url https://logs-01.loggly.com/inputs/TOKEN/tag/fluentd
+  loggly_url https://logs-01.loggly.com/inputs/<TOKEN>/tag/fluentd
 </plugin>
 ```
 


### PR DESCRIPTION
- Updated the example used for the `admin` namespace configuration to include a `match` directive to support a fully working example.
- The original example was incomplete and led me to believe the `plugin` directive also sent logs in addition to being re-used by namespace configurations; it was not until I added the `match` directive that I noticed it worked.
- Signed-off-by: Shazad Brohi <sbrohi@vmware.com>