### PR TITLE
Expose config-reloader prometheus metrics

### DIFF
--- a/charts/log-router/templates/daemonset.yaml
+++ b/charts/log-router/templates/daemonset.yaml
@@ -81,6 +81,11 @@ spec:
         - name: reloader
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.prometheusEnabled }}
+          ports:
+          - name: metrics
+            containerPort: {{ default 9000 .Values.metricsPort }}
+          {{- end }}
           {{- if .Values.reloader.extraEnv }}
           env:
         {{- range $key, $value := .Values.reloader.extraEnv }}
@@ -118,6 +123,7 @@ spec:
           {{- end }}
           {{- if .Values.prometheusEnabled }}
           - --prometheus-enabled
+          - --metrics-port={{ default 9000 .Values.metricsPort }}
           {{- end }}
           {{- if and (eq .Values.datasource "multimap") .Values.labelSelector.matchLabels }}
           - --label-selector={{- range $k, $v := .Values.labelSelector.matchLabels }}{{$k}}={{$v}},

--- a/charts/log-router/templates/service.yaml
+++ b/charts/log-router/templates/service.yaml
@@ -11,6 +11,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    metrics: fluentd
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "24231"
@@ -23,4 +24,28 @@ spec:
     - port: 24231
       name: prometheus
       targetPort: prometheus
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "fluentd-router.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    metrics: reloader
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.metricsPort | quote }}
+  name: {{ template "fluentd-router.fullname" . }}-reloader
+spec:
+  selector:
+    app: {{ template "fluentd-router.name" . }}
+    release: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.metricsPort }}
+      name: metrics
+      targetPort: metrics
 {{- end }}

--- a/charts/log-router/templates/servicemonitor.yaml
+++ b/charts/log-router/templates/servicemonitor.yaml
@@ -14,8 +14,33 @@ spec:
     matchLabels:
       app: {{ template "fluentd-router.name" . }}
       release: {{ .Release.Name }}
+      metrics: fluentd
   endpoints:
   - port: prometheus
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "fluentd-router.fullname" . }}-reloader
+  labels:
+    app: {{ template "fluentd-router.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: {{ template "fluentd-router.name" . }}
+      release: {{ .Release.Name }}
+      metrics: reloader
+  endpoints:
+  - port: metrics
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
     {{- end }}

--- a/charts/log-router/values.yaml
+++ b/charts/log-router/values.yaml
@@ -89,6 +89,7 @@ updateStrategy: {}
 #  scheduler.alpha.kubernetes.io/tolerations: '[{"key": "example", "value": "foo"}]'
 
 prometheusEnabled: false
+metricsPort: 9000
 
 ### Disable privileged access and running service as root
 #securityContext:

--- a/config-reloader/Gopkg.lock
+++ b/config-reloader/Gopkg.lock
@@ -29,6 +29,14 @@
   revision = "f65c72e2690dc4b403c8bd637baf4611cd4c069b"
 
 [[projects]]
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "37c8de3658fcb183f997c4e13e8337516ab753e6"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -139,6 +147,14 @@
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -169,6 +185,50 @@
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:eb04f69c8991e52eff33c428bd729e04208bf03235be88e4df0d88497c6861b9"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "170205fb58decfd011f1550d4cfb737230d7ae4f"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:0db23933b8052702d980a3f029149b3f175f7c0eea0cff85b175017d0f2722c0"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "7bc5445566f0fe75b15de23e6b93886e982d7bf9"
+  version = "v0.2.0"
+
+[[projects]]
+  digest = "1:4407525bde4e6ad9c1f60113d38cbb255d769e0ea506c8cf877db39da7753b3a"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "317b7b125e8fddda956d0c9574e5f03f438ed5bc"
+  version = "v0.14.0"
+
+[[projects]]
+  digest = "1:b2268435af85ee1a0fca0e37de4225f78e2d9d8b0b66acde3a29f127634efa87"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/fs",
+    "internal/util",
+  ]
+  pruneopts = "UT"
+  revision = "9dece15c53cd5e9fbfbd72d5108adcf526a3f486"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:0599141a8403114d34f1e546604ad6c5361b70dfa80e80c635f438cdbf71b43a"
@@ -633,6 +693,8 @@
   analyzer-version = 1
   input-imports = [
     "github.com/alecthomas/kingpin",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/core/v1",

--- a/config-reloader/config/config.go
+++ b/config-reloader/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	KubeletRoot            string
 	Namespaces             []string
 	PrometheusEnabled      bool
+	MetricsPort            int
 	AllowTagExpansion      bool
 	AdminNamespace         string
 	// parsed or processed/cached fields
@@ -68,6 +69,7 @@ var defaultConfig = &Config{
 	IntervalSeconds:      60,
 	ID:                   "default",
 	PrometheusEnabled:    false,
+	MetricsPort:          9000,
 	AdminNamespace:       "kube-system",
 }
 
@@ -206,6 +208,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("status-annotation", "Store configuration errors in this annotation, leave empty to turn off").Default(defaultConfig.AnnotStatus).StringVar(&cfg.AnnotStatus)
 
 	app.Flag("prometheus-enabled", "Prometheus metrics enabled (default: false)").BoolVar(&cfg.PrometheusEnabled)
+	app.Flag("metrics-port", "Expose prometheus metrics on this port (also needs --prometheus-enabled)").Default(strconv.Itoa(defaultConfig.MetricsPort)).IntVar(&cfg.MetricsPort)
 
 	app.Flag("kubelet-root", "Kubelet root dir, configured using --root-dir on the kubelet service").Default(defaultConfig.KubeletRoot).StringVar(&cfg.KubeletRoot)
 	app.Flag("namespaces", "List of namespaces to process. If empty, processes all namespaces").StringsVar(&cfg.Namespaces)

--- a/config-reloader/generator/generator.go
+++ b/config-reloader/generator/generator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vmware/kube-fluentd-operator/config-reloader/config"
 	"github.com/vmware/kube-fluentd-operator/config-reloader/datasource"
 	"github.com/vmware/kube-fluentd-operator/config-reloader/fluentd"
+	"github.com/vmware/kube-fluentd-operator/config-reloader/metrics"
 	"github.com/vmware/kube-fluentd-operator/config-reloader/processors"
 	"github.com/vmware/kube-fluentd-operator/config-reloader/util"
 
@@ -282,6 +283,7 @@ func (g *Generator) makeContext(ns *datasource.NamespaceConfig, genCtx *processo
 }
 
 func (g *Generator) updateStatus(namespace string, status string) {
+	metrics.SetNamespaceConfigStatusMetric(namespace, status == "")
 	g.su.UpdateStatus(namespace, status)
 }
 
@@ -325,6 +327,7 @@ func (g *Generator) CleanupUnusedFiles(outputDir string, namespaces map[string]s
 			if err := os.Remove(f); err != nil {
 				logrus.Warnf("Error removing unused file %s: %+v", f, err)
 			}
+			metrics.DeleteNamespaceConfigStatusMetric(ns)
 		}
 	}
 }

--- a/config-reloader/main.go
+++ b/config-reloader/main.go
@@ -4,12 +4,14 @@
 package main
 
 import (
-	"github.com/vmware/kube-fluentd-operator/config-reloader/config"
-	"github.com/vmware/kube-fluentd-operator/config-reloader/controller"
-	"github.com/vmware/kube-fluentd-operator/config-reloader/fluentd"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/vmware/kube-fluentd-operator/config-reloader/config"
+	"github.com/vmware/kube-fluentd-operator/config-reloader/controller"
+	"github.com/vmware/kube-fluentd-operator/config-reloader/fluentd"
+	"github.com/vmware/kube-fluentd-operator/config-reloader/metrics"
 
 	"github.com/sirupsen/logrus"
 )
@@ -50,6 +52,10 @@ func main() {
 
 	stopChan := make(chan struct{}, 1)
 	go handleSigterm(stopChan)
+
+	if cfg.PrometheusEnabled {
+		metrics.InitMetrics(cfg.MetricsPort)
+	}
 
 	ctrl.Run(stopChan)
 }

--- a/config-reloader/metrics/metrics.go
+++ b/config-reloader/metrics/metrics.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	LabelTargetNamespace = "target_namespace"
+)
+
+var namespaceConfigStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "kube_fluentd_operator",
+	Name:      "namespace_config_status",
+	Help:      "Current validation status of fluentd configs in the namespace. Values are 0 (validation error) or 1 (validation successful)",
+}, []string{LabelTargetNamespace})
+
+// SetNamespaceConfigStatusMetric sets the current metric value for a given namespace
+func SetNamespaceConfigStatusMetric(namespace string, valid bool) {
+	var value float64 = 0
+	if valid {
+		value = 1
+	}
+
+	namespaceConfigStatus.With(prometheus.Labels{LabelTargetNamespace: namespace}).Set(value)
+}
+
+// DeleteNamespaceConfigStatusMetric deletes the metric value for a given namespace
+func DeleteNamespaceConfigStatusMetric(namespace string) {
+	namespaceConfigStatus.Delete(prometheus.Labels{LabelTargetNamespace: namespace})
+}
+
+// InitMetrics should be called to initialize metrics and start the HTTP handler
+func InitMetrics(port int) error {
+	if err := serveMetrics(port); err != nil {
+		return fmt.Errorf("Failed to start metrics handler: %s", err)
+	}
+
+	registerMetrics()
+	return nil
+}
+
+func registerMetrics() {
+	prometheus.MustRegister(namespaceConfigStatus)
+}
+
+func serveMetrics(port int) error {
+	ln, err := net.Listen("tcp", ":"+strconv.Itoa(port))
+	if err != nil {
+		return err
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	srv := &http.Server{Handler: mux}
+	go func() {
+		srv.Serve(ln)
+	}()
+	return nil
+}


### PR DESCRIPTION
Currently, when config-reloader fails to validate the fluentd configurations
for a given namespace, an error is logged and is attached to the namespace
via an annotation. This system, however, requires users to actively look
at namespace annotations or logs to ensure no errors are present whenever
a change in a fluentd configuration is deployed.
Users that are already utilizing Prometheus in their Kubernetes clusters,
are most likely measuring applications' stability via metrics and routing
alerts to a central location, where they are more visible.

This commit introduces the capability for config-reloader to expose its
own Prometheus metrics, which provide a simple boolean metric per
namespace exposing whether the fluentd configs in that namespace passed
validation or not.
These simple metrics allow users to define rules in Prometheus to alert
in case a namespace is throwing errors in fluentd configurations validation.
Such a rule can look something like
```
alert: FluentdConfigValidationFailure
expr: kube_fluentd_operator_namespace_config_status{} == 0
```

This commit also adds the possibility of configuring the port that the
config-reloader will be listening on to expose such metrics via a flag.
Furthermore it adds the necessary resources to the helm chart to ensure
that, if the `prometheusEnabled` value is set to `true`, the corresponding
Services and, if enabled, ServiceMonitors are also created.