### PR TITLE
Update log intelligence plugin to 2.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ This projects tries to keep up with major releases for [Fluentd docker image](ht
 * fluent-plugin-uri-parser (0.3.0)
 * fluent-plugin-verticajson (0.0.6)
 * fluent-plugin-vmware-loginsight (0.1.7)
-* fluent-plugin-vmware-log-intelligence (2.0.0)
+* fluent-plugin-vmware-log-intelligence (2.0.4)
 * fluentd (1.9.1)
 
 When customizing the image be careful not to uninstall plugins that are used internally to implement the macros.

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -43,14 +43,17 @@ RUN mkdir -p /fluentd/log /fluentd/etc /fluentd/plugins /usr/local/bundle/bin/ \
 	&& wget https://raw.githubusercontent.com/fluent/fluentd-kubernetes-daemonset/master/docker-image/v1.4/debian-elasticsearch/plugins/parser_multiline_kubernetes.rb -P /fluentd/plugins \
 	&& echo 'gem: --no-document' >> /etc/gemrc \
 	&& bundle config silence_root_warning true \
-	&& wget https://github.com/vmware/fluent-plugin-vmware-log-intelligence/releases/download/v2.0.0/fluent-plugin-vmware-log-intelligence-2.0.0.gem \
+	# since fluent-plugin-vmware-log-intelligence is not available in rubygems, should be removed once it is published as rubygems
+	&& wget https://github.com/vmware/fluent-plugin-vmware-log-intelligence/releases/download/v2.0.4/fluent-plugin-vmware-log-intelligence-2.0.4.gem \
 	&& bundle install --gemfile=/fluentd/Gemfile \
-	&& fluent-gem install --local fluent-plugin-vmware-log-intelligence-2.0.0.gem \
+	# fluent-plugin-mysqlslowquery is a dependency of fluent-plugin-vmware-log-intelligence
+	&& fluent-gem install fluent-plugin-mysqlslowquery -v 0.0.9 \
+	&& fluent-gem install --local fluent-plugin-vmware-log-intelligence-2.0.4.gem \
 	&& tdnf clean all \
 	&& gem sources --clear-all \
 	&& ln -s $(which fluentd) /usr/local/bundle/bin/fluentd \
 	&& tdnf remove -y $buildDeps \
-	&& rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /fluent-plugin-vmware-log-intelligence-2.0.0.gem
+	&& rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /fluent-plugin-vmware-log-intelligence-2.0.4.gem
 
 EXPOSE 24444 5140
 COPY plugins /fluentd/plugins

--- a/charts/log-router/Chart.yaml
+++ b/charts/log-router/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 description: Distribution of Fluentd as K8S daemonset
 name: log-router
-version: 0.3.4
+version: 0.3.5
 home: https://github.com/vmware/kube-fluentd-operator
 sources:
   - https://github.com/vmware/kube-fluentd-operator


### PR DESCRIPTION
Update fluent-plugin-vmware-log-intelligence plugin to 2.0.4

Add fluent-plugin-mysqlslowquery which is a dependency of  fluent-plugin-vmware-log-intelligence

Update helm chart version to 0.3.5

Signed-off-by: Vivek Singh <svivekkumar@vmware.com>