### PR TITLE
Add timeout for fluentd validate command run

### DIFF
--- a/config-reloader/fluentd/validator.go
+++ b/config-reloader/fluentd/validator.go
@@ -71,7 +71,7 @@ func (v *validatorState) ValidateConfigExtremely(config string, namespace string
 	args := make([]string, len(v.args))
 	copy(args, v.args)
 
-	args = append(args, "-qq", "--no-supervisor", "-c", tmpfile.Name())
+	args = append(args, "--no-supervisor", "-c", tmpfile.Name())
 
 	out, err := util.ExecAndGetOutput(v.command, args...)
 

--- a/config-reloader/util/util.go
+++ b/config-reloader/util/util.go
@@ -96,7 +96,7 @@ func ExecAndGetOutput(cmd string, args ...string) (string, error) {
 	}()
 
 	select {
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		if err = c.Process.Kill(); err != nil {
 			err = fmt.Errorf("process killed as timeout reached after 10s,but kill failed with err:%s",err.Error())
 		} else {

--- a/config-reloader/util/util.go
+++ b/config-reloader/util/util.go
@@ -7,11 +7,13 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os/exec"
 	"sort"
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -78,8 +80,31 @@ func SortedKeys(m map[string]string) []string {
 
 func ExecAndGetOutput(cmd string, args ...string) (string, error) {
 	c := exec.Command(cmd, args...)
-	out, err := c.CombinedOutput()
+	var b bytes.Buffer
+	c.Stdout = &b
+	c.Stderr = &b
+	var err error
+	if err = c.Start(); err != nil {
+		out := b.Bytes()
+		return string(out), err
+	}
 
+	// Wait for the process to finish or kill it after a timeout (whichever happens first):
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Wait()
+	}()
+
+	select {
+	case <-time.After(10 * time.Second):
+		if err = c.Process.Kill(); err != nil {
+			err = fmt.Errorf("process killed as timeout reached after 10s,but kill failed with err:%s",err.Error())
+		} else {
+			err = errors.New("process killed as timeout reached after 10s")
+		}
+	case err = <-done:
+	}
+	out := b.Bytes()
 	return string(out), err
 }
 


### PR DESCRIPTION
If there is wrong fluentd config,fluentd validate command may stuck,case fluentd.conf file can not be created.
for example,there is an unreachble elasticsearch server , fluentd will try to connect to the elasticserver forerver,and because the "-qq" ,there is no output in the debug level log
the fluentd pod crash,because the fluentd.conf was not create by the config-reloader.
remove the "-qq" and add 30s timeout for the fluentd validata command run,so the config-reloader won't stuck,and the fluentd can run