### PR TITLE
Add timeout for fluentd validate command run

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: engineerd/setup-kind@v0.4.0
+      - uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.9.0"
       - uses: FranzDiebold/github-env-vars-action@v1.2.1

--- a/config-reloader/fluentd/validator.go
+++ b/config-reloader/fluentd/validator.go
@@ -71,7 +71,7 @@ func (v *validatorState) ValidateConfigExtremely(config string, namespace string
 	args := make([]string, len(v.args))
 	copy(args, v.args)
 
-	args = append(args, "-qq", "--no-supervisor", "-c", tmpfile.Name())
+	args = append(args, "--no-supervisor", "-c", tmpfile.Name())
 
 	out, err := util.ExecAndGetOutput(v.command, args...)
 


### PR DESCRIPTION
If there is wrong fluentd config,fluentd validate command may stuck,case fluentd.conf file can not be created.
for example,there is an unreachble elasticsearch server , fluentd will try to connect to the elasticserver forerver,and because the "-qq" ,there is no output in the debug level log
the fluentd pod crash,because the fluentd.conf was not create by the config-reloader.
remove the "-qq" and add 30s timeout for the fluentd validata command run,so the config-reloader won't stuck,and the fluentd can run
