### PR TITLE
chore: get vmware-log-intelligence from rubygems

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -46,17 +46,11 @@ RUN mkdir -p /fluentd/log /fluentd/etc /fluentd/plugins /usr/local/bundle/bin/ \
 	&& wget https://raw.githubusercontent.com/fluent/fluentd-kubernetes-daemonset/master/docker-image/v1.4/debian-elasticsearch/plugins/parser_multiline_kubernetes.rb -P /fluentd/plugins \
 	&& echo 'gem: --no-document' >> /etc/gemrc \
 	&& bundle config silence_root_warning true \
-	# since fluent-plugin-vmware-log-intelligence is not available in rubygems, should be removed once it is published as rubygems
-	&& wget https://github.com/vmware/fluent-plugin-vmware-log-intelligence/releases/download/v2.0.4/fluent-plugin-vmware-log-intelligence-2.0.4.gem \
 	&& bundle install --gemfile=/fluentd/Gemfile \
-	# fluent-plugin-mysqlslowquery is a dependency of fluent-plugin-vmware-log-intelligence
-	&& fluent-gem install fluent-plugin-mysqlslowquery -v 0.0.9 \
-	&& fluent-gem install --local fluent-plugin-vmware-log-intelligence-2.0.4.gem \
 	&& tdnf clean all \
 	&& gem sources --clear-all \
 	&& ln -s $(which fluentd) /usr/local/bundle/bin/fluentd \
-	&& tdnf remove -y $buildDeps \
-	&& rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /fluent-plugin-vmware-log-intelligence-2.0.4.gem
+	&& tdnf remove -y $buildDeps
 
 EXPOSE 24444 5140
 COPY plugins /fluentd/plugins

--- a/base-image/Gemfile
+++ b/base-image/Gemfile
@@ -44,5 +44,8 @@ gem 'fluent-plugin-systemd', "1.0.2"
 gem 'fluent-plugin-uri-parser', "0.3.0"
 gem 'fluent-plugin-verticajson', "0.0.6"
 gem 'fluent-plugin-vmware-loginsight', "0.1.10"
+gem 'fluent-plugin-vmware-log-intelligence', "2.0.5"
+# fluent-plugin-mysqlslowquery is dependency for fluent-plugin-vmware-log-intelligence
+gem 'fluent-plugin-mysqlslowquery', "0.0.9"
 gem 'gelf', "3.1.0"
 gem 'logfmt', "0.0.9"


### PR DESCRIPTION
   - update fluent-plugin-vmware-log-intelligence to 2.0.5
   - version fluent-plugin-vmware-log-intelligence from rubygems (resolves #172)

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>