### PR TITLE
Add timeout and log for validation

### DIFF
--- a/config-reloader/fluentd/validator_test.go
+++ b/config-reloader/fluentd/validator_test.go
@@ -5,6 +5,7 @@ package fluentd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +19,7 @@ func TestValidConfigString(t *testing.T) {
 	</match>
 	`
 
-	validator := NewValidator(validateCommand)
+	validator := NewValidator(validateCommand, 30*time.Second)
 
 	err := validator.EnsureUsable()
 	assert.Nil(t, err, "Must succeed but failed with: %+v", err)
@@ -28,7 +29,7 @@ func TestValidConfigString(t *testing.T) {
 }
 
 func TestUnusable(t *testing.T) {
-	validator := NewValidator("./no-such command")
+	validator := NewValidator("./no-such command", 30*time.Second)
 
 	err := validator.EnsureUsable()
 	assert.NotNil(t, err, "Must have failed")
@@ -42,7 +43,7 @@ func TestBadConfigString(t *testing.T) {
 	</match>
 	`
 
-	validator := NewValidator(validateCommand)
+	validator := NewValidator(validateCommand, 30*time.Second)
 
 	err := validator.EnsureUsable()
 	assert.Nil(t, err, "Must succeed but failed with: %+v", err)

--- a/config-reloader/generator/generator.go
+++ b/config-reloader/generator/generator.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/vmware/kube-fluentd-operator/config-reloader/config"
 	"github.com/vmware/kube-fluentd-operator/config-reloader/datasource"
@@ -377,7 +378,7 @@ func New(cfg *config.Config) *Generator {
 	var validator fluentd.Validator
 
 	if cfg.FluentdValidateCommand != "" {
-		validator = fluentd.NewValidator(cfg.FluentdValidateCommand)
+		validator = fluentd.NewValidator(cfg.FluentdValidateCommand, time.Second*time.Duration(cfg.ExecTimeoutSeconds))
 	}
 
 	return &Generator{

--- a/config-reloader/main.go
+++ b/config-reloader/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/vmware/kube-fluentd-operator/config-reloader/config"
 	"github.com/vmware/kube-fluentd-operator/config-reloader/controller"
@@ -31,7 +32,7 @@ func main() {
 	}
 
 	if cfg.FluentdValidateCommand != "" {
-		validator := fluentd.NewValidator(cfg.FluentdValidateCommand)
+		validator := fluentd.NewValidator(cfg.FluentdValidateCommand, time.Second*time.Duration(cfg.ExecTimeoutSeconds))
 		if err := validator.EnsureUsable(); err != nil {
 			logrus.Fatalf("Bad validate command used: '%s', either use correct one or none at all: %+v",
 				cfg.FluentdValidateCommand, err)


### PR DESCRIPTION
Add timeout during exec for validate command of the config, so that it does not hang forever while validating
configuration. Also adds log on failure in validation of configs.

Signed-off-by: Vivek Singh <svivekkumar@vmware.com>