### PR TITLE
chore: update changelogs and couple fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # CHANGELOG
 
+## [v1.14.0-beta.2](https://github.com/vmware/kube-fluentd-operator/releases/tag/v1.14.0-beta.2)
+
+#### Core:
+  - Migrate to go modules (#152) (@viveksyngh)
+  - Add timeout and log for validation (#180) (@viveksyngh)
+
+#### CI:
+  - Update kind github action to fix ci (#152) (@viveksyngh)
+  - Remove travis ci config (#169) (@viveksyngh)
+
+#### Helm:
+  - Fix helm chart deprecated endpoints (#168) (@slimm609)
+  - Update helm to helm3 in ci (#170) (@viveksyngh)
+  - Adds support for SA annotations (#167) (@kkapoor1987)
+
+#### Plugins:
+  - Update ruby, fluentd, and gem plugins (#173) (@Cryptophobia)
+      - Update fluentd gem to 1.11.2
+      - Update ruby version to 2.7.2 (webrick CVE)
+      - **DEPRECATION**: removing fluent-plugin-scribe as no longer maintained
+  - Get vmware-log-intelligence from rubygems (#174) (@Cryptophobia)
+      - Update fluent-plugin-vmware-log-intelligence to 2.0.5
+  - Feat(splunk-hec): add plugin & fix dependencies (#179) (@jliao2011)
+      - fluent-plugin-splunk-hec is added
+
+## [1.14.0-beta.1](https://github.com/vmware/kube-fluentd-operator/releases/tag/v1.14.0-beta.1)
+
+* Core: Expose config-reloader prometheus metrics (#147) (@tommasopozzetti )
+* CI: Update github action to include kind test (#148) (@viveksyngh)
+* Plugin: Update log intelligence plugin to 2.0.4 (#150) (@viveksyngh)
+
+## [1.13.0](https://github.com/vmware/kube-fluentd-operator/releases/tag/v1.13.0)
+
+* Core: Introduce 'crd' datasource (#111) (@tommasopozzetti )
+* Helm: improve Helm chart and bump version to 0.3.4 (#130) (@dimalbaby )
+* Core: Make the admin namespace configurable (#118 )(@tommasopozzetti )
+* Helm: PriorityClassName and add ServiceMonitor in helm chart (#102)(@evilrussian )
+* Image: Reduce image size (@dimalbaby )
+* Core: Update CI github workflows (#129) (@tsunny )
+* Plugin: Upgrade fluent-plugin-azure-loganalytics plugin (#136) (@floriankoch )
+
+## [1.13.0-beta.2](https://github.com/vmware/kube-fluentd-operator/releases/tag/v1.13.0-beta.2)
+
+* Helm: improve Helm chart and bump version to 0.3.4 (#130) (@dimalbaby )
+
+## [1.13.0-beta.1](https://github.com/vmware/kube-fluentd-operator/releases/tag/v1.13.0-beta.1)
+
+* Core: Introduce 'crd' datasource (#111) (@tommasopozzetti )
+* Core: Make the admin namespace configurable (#118 )(@tommasopozzetti )
+* Helm: PriorityClassName and add ServiceMonitor in helm chart (#102)(@evilrussian)
+* Image: Reduce image size
+
 ## [1.12.0](https://github.com/vmware/kube-fluentd-operator/releases/tag/v1.12.0)
 
 * Build kube-fluentd-operator on photon (#115) (@dimalbaby)

--- a/README.md
+++ b/README.md
@@ -102,12 +102,13 @@ cd charts/log-router && make
 
 # build the daemon
 cd config-reloader
-# get vendor/ deps, you need to have "dep" tool installed
-make dep
 make install
 
 # run with mock data (loaded from the examples/ folder)
-make run-local-fs
+make run-once-fs
+
+# run with mock data in a loop (may need to ctrl+z to exit)
+make run-loop-fs
 
 # inspect what is generated from the above command
 ls -l tmp/
@@ -351,7 +352,7 @@ admin-ns.conf:
 </plugin>
 ```
 
-In the above example for the admin configuration, the `match` directive is first defined to direct where to send logs for the `systemd`, `docker`, `kube-system`, and kubernetes control plane components. Below the `match` directive we have defined the `plugin` directives which define the log sinks that can be reused by namespace configurations. 
+In the above example for the admin configuration, the `match` directive is first defined to direct where to send logs for the `systemd`, `docker`, `kube-system`, and kubernetes control plane components. Below the `match` directive we have defined the `plugin` directives which define the log sinks that can be reused by namespace configurations.
 
 A namespace can refer to the `staging` and `test` plugins oblivious to the fact where exactly the logs end up:
 

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -10,7 +10,30 @@ FROM photon:3.0 AS rubybuild
 ARG RUBY_PATH
 ARG RUBY_VERSION
 ARG RUBYOPT
-RUN tdnf erase -y toybox && tdnf install -y bzip2 shadow wget which vim less tar gzip util-linux sed gcc build-essential zlib-devel libedit libedit-devel gdbm gdbm-devel openssl-devel systemd net-tools git
+RUN tdnf upgrade -y && \
+    tdnf erase -y toybox && \
+    tdnf install -y \
+         bzip2 \
+         shadow \
+         wget \
+         which \
+         vim \
+         less \
+         tar \
+         gzip \
+         util-linux \
+         sed \
+         gcc \
+         build-essential \
+         zlib-devel \
+         libedit \
+         libedit-devel \
+         gdbm \
+         gdbm-devel \
+         openssl-devel \
+         systemd \
+         net-tools \
+         git
 
 COPY basegems/Gemfile Gemfile
 RUN git clone git://github.com/rbenv/ruby-build.git $RUBY_PATH/plugins/ruby-build \


### PR DESCRIPTION
  - Update changelogs file to be up-to-date to release v1.14.0-beta.2
  - Remove go dep from build instructions (we use go modules)
  - Fix minor errors in build instructions
  - Add `tdnf upgrade -y` step to base-image Dockerfile

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>