### PR TITLE
chore(base-image): upgrade to use photon:4.0

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -6,7 +6,7 @@ ARG RUBY_PATH=/usr/local
 ARG RUBY_VERSION=2.7.2
 ARG RUBYOPT='-W:no-deprecated -W:no-experimental'
 
-FROM photon:3.0 AS rubybuild
+FROM photon:4.0 AS rubybuild
 ARG RUBY_PATH
 ARG RUBY_VERSION
 ARG RUBYOPT
@@ -43,7 +43,7 @@ RUN git clone git://github.com/rbenv/ruby-build.git $RUBY_PATH/plugins/ruby-buil
     && gem uninstall rake -v 13.0.3 \
     && gem uninstall bigdecimal -v 3.0.0
 
-FROM photon:3.0
+FROM photon:4.0
 ARG RUBY_PATH
 ARG RUBYOPT
 ENV PATH $RUBY_PATH/bin:$PATH


### PR DESCRIPTION
 - upgrade to use photon:4.0
 - upgrades systemd to 247 and enables l4z compression
 - fixes #141
 - resolves #184

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>