### PR TITLE
chore: upgrade vmware-log-intelligence to 2.0.6

### DIFF
--- a/base-image/Gemfile
+++ b/base-image/Gemfile
@@ -45,7 +45,7 @@ gem 'fluent-plugin-systemd', "1.0.2"
 gem 'fluent-plugin-uri-parser', "0.3.0"
 gem 'fluent-plugin-verticajson', "0.0.6"
 gem 'fluent-plugin-vmware-loginsight', "0.1.10"
-gem 'fluent-plugin-vmware-log-intelligence', "2.0.5"
+gem 'fluent-plugin-vmware-log-intelligence', "2.0.6"
 # fluent-plugin-mysqlslowquery is dependency for fluent-plugin-vmware-log-intelligence
 gem 'fluent-plugin-mysqlslowquery', "0.0.9"
 gem 'gelf', "3.1.0"


### PR DESCRIPTION
 - upgrade fluent-plugin-vmware-log-intelligence gem to v2.0.6 latest

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>