### PR TITLE
Move to graceful reload endpoint and error

### DIFF
--- a/config-reloader/fluentd/reloader.go
+++ b/config-reloader/fluentd/reloader.go
@@ -28,9 +28,9 @@ func (r *Reloader) ReloadConfiguration() {
 		logrus.Infof("Not reloading fluentd (fake or filesystem datasource used)")
 		return
 	}
-	_, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/api/config.reload", r.port), "application/json", nil)
+	_, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/api/config.gracefulReload", r.port), "application/json", nil)
 
 	if err != nil {
-		logrus.Infof("cannot notify fluentd: %+v", err)
+		logrus.Errorf("cannot notify fluentd: %+v", err)
 	}
 }

--- a/config-reloader/fluentd/reloader_test.go
+++ b/config-reloader/fluentd/reloader_test.go
@@ -23,7 +23,7 @@ func TestReloaderCalls(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("req %+v", r)
-		if r.Method == "POST" && r.RequestURI == "/api/config.reload" {
+		if r.Method == "POST" && r.RequestURI == "/api/config.gracefulReload" {
 			counter++
 		}
 	}


### PR DESCRIPTION
Move to gracefulReload endpoint to align with upstream docs after 1.9
Change failure to an error instead of info

Signed-off-by: Brian Davis <slimm609@gmail.com>