### PR TITLE
fix(config-reloader): add timeout seconds on startup

### DIFF
--- a/config-reloader/main.go
+++ b/config-reloader/main.go
@@ -46,6 +46,13 @@ func main() {
 		logrus.Fatalf("Cannot start control loop %+v", err)
 	}
 
+	// Add this for a timeout between 0-120 seconds (default: 30 (ExecTimeoutSeconds))
+	// This is for golang/fluentd race condition when KFO starts/restarts:
+	if cfg.ExecTimeoutSeconds > 0 && cfg.ExecTimeoutSeconds <= 120 {
+		logrus.Infof("Sleeping for %v seconds in order for fluentd to be ready.", cfg.ExecTimeoutSeconds)
+		time.Sleep(time.Second * time.Duration(cfg.ExecTimeoutSeconds))
+	}
+
 	if cfg.IntervalSeconds == 0 {
 		ctrl.RunOnce()
 		return


### PR DESCRIPTION
  - fix race condition when config-reloader start or restarts
  - add a timeout default to 30 seconds, that is between 0 - 60 seconds based on cfg.ExecTimeoutSeconds

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>