### PR TITLE
Make fluentd log level configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,8 @@ Flags:
   --id="default"                The id of this deployment. It is used internally so that two
                                 deployments don't overwrite each other's data
   --fluentd-rpc-port=24444      RPC port of Fluentd
-  --log-level="info"            Control verbosity of log
+  --log-level="info"            Control verbosity of config-reloader logs
+  --fluentd-loglevel="info"     Control verbosity of fluentd logs
   --annotation="logging.csp.vmware.com/fluentd-configmap"
                                 Which annotation on the namespace stores the configmap name?
   --default-configmap="fluentd-config"
@@ -654,7 +655,8 @@ Flags:
 | `image.tag`                              | Image tag                | `latest`                          |
 | `image.pullPolicy`                       | Pull policy                 | `Always`                             |
 | `image.pullSecret`                       | Optional pull secret name                 | `""`                                |
-| `logLevel`                               | Default log level                 | `info`                               |
+| `logLevel`                               | Default log level for config-reloader                | `info`                               |
+| `fluentdLogLevel`                        | Default log level for fluentd               | `info`                               |
 | `kubeletRoot`                            | The home dir of the kubelet, usually set using `--root-dir` on the kubelet           | `/var/lib/kubelet`                               |
 | `namespaces`                             | List of namespaces to operate on. Empty means all namespaces                 | `[]`                               |
 | `interval`                               | How often to check for config changes (seconds)                 | `45`          |

--- a/charts/log-router/Chart.yaml
+++ b/charts/log-router/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 description: Distribution of Fluentd as K8S daemonset
 name: log-router
-version: 0.3.6
+version: 0.3.7
 home: https://github.com/vmware/kube-fluentd-operator
 sources:
   - https://github.com/vmware/kube-fluentd-operator

--- a/charts/log-router/templates/daemonset.yaml
+++ b/charts/log-router/templates/daemonset.yaml
@@ -105,6 +105,7 @@ spec:
           - --default-configmap={{ .Values.defaultConfigmap }}
           - --interval={{ .Values.interval }}
           - --log-level={{ .Values.logLevel }}
+          - --fluentd-loglevel={{ .Values.fluentdLoglevel }}
           - --output-dir=/fluentd/etc
           - --templates-dir=/templates
           - --id={{ template "fluentd-router.fullname" . }}

--- a/charts/log-router/templates/daemonset.yaml
+++ b/charts/log-router/templates/daemonset.yaml
@@ -105,7 +105,7 @@ spec:
           - --default-configmap={{ .Values.defaultConfigmap }}
           - --interval={{ .Values.interval }}
           - --log-level={{ .Values.logLevel }}
-          - --fluentd-loglevel={{ .Values.fluentdLoglevel }}
+          - --fluentd-loglevel={{ .Values.fluentdLogLevel }}
           - --output-dir=/fluentd/etc
           - --templates-dir=/templates
           - --id={{ template "fluentd-router.fullname" . }}

--- a/charts/log-router/values.yaml
+++ b/charts/log-router/values.yaml
@@ -31,6 +31,7 @@ image:
 
 
 logLevel: debug
+fluentdLoglevel: debug
 interval: 45
 kubeletRoot: /var/lib/kubelet
 

--- a/config-reloader/Makefile
+++ b/config-reloader/Makefile
@@ -64,6 +64,7 @@ run-once-fs: install
 	config-reloader \
 	  --interval 0 \
 	  --log-level=debug \
+	  --fluentd-loglevel=debug \
 	  --output-dir=tmp \
 	  --meta-key=prefix2 \
 	  --meta-values=aws_region=us-west-2,csp_cluster=mon \
@@ -77,6 +78,7 @@ run-once: install
 	config-reloader \
 	  --interval 0 \
 	  --log-level=debug \
+	  --fluentd-loglevel=debug \
 	  --output-dir=tmp \
 	  --templates-dir=templates \
 	  --meta-key=run-once \
@@ -88,6 +90,7 @@ run-loop: install
 	config-reloader \
 	  --interval 5 \
 	  --log-level=debug \
+	  --fluentd-loglevel=debug \
 	  --output-dir=tmp \
 	  --meta-key=prefix3 \
 	  --meta-values=aws_region=us-west-2,csp_cluster=mon \

--- a/config-reloader/config/config_test.go
+++ b/config-reloader/config/config_test.go
@@ -15,6 +15,7 @@ func TestBadConfigs(t *testing.T) {
 		{"--datasource", "fs"},
 		{"--id", "???"},
 		{"--log-level", "hobbit"},
+		{"--fluentd-loglevel", "hobbit"},
 		{"--annotation", "|kl"},
 		{"--status-annotation", "/hello"},
 		{"--meta-key=test"},

--- a/config-reloader/generator/generator.go
+++ b/config-reloader/generator/generator.go
@@ -110,12 +110,17 @@ func (g *Generator) renderMainFile(mainFile string, outputDir string, dest strin
 		Namespaces              []string
 		MetaKey                 string
 		MetaValue               string
+		FluentdLogLevel         string
 		PreprocessingDirectives []string
 	}{}
 
 	if g.cfg.MetaKey != "" {
 		model.MetaKey = g.cfg.MetaKey
 		model.MetaValue = util.ToRubyMapLiteral(g.cfg.ParsedMetaValues)
+	}
+
+	if g.cfg.FluentdLogLevel != "" {
+		model.FluentdLogLevel = g.cfg.FluentdLogLevel
 	}
 
 	genCtx := &processors.GenerationContext{

--- a/config-reloader/templates/fluent.conf
+++ b/config-reloader/templates/fluent.conf
@@ -1,7 +1,7 @@
 # dont modify this file when building on top of the image
 
 <system>
-  log_level info
+  log_level {{ .FluentdLogLevel }}
 
   # needed to enable /api/config.reload
   rpc_endpoint 127.0.0.1:24444


### PR DESCRIPTION
Solves #181
* Tested by changing to different log level which fluentd supports 
*  If loglevel provided is not supported then we fail with validation error. 
*  If log level is not provided then default logLevel `info` is used

Signed-off-by: Karan Kapoor karan.kapoor@pega.com