### PR TITLE
fix(reloader): matadata/labels key can have a period .

### DIFF
--- a/config-reloader/config/config.go
+++ b/config-reloader/config/config.go
@@ -137,9 +137,6 @@ func (cfg *Config) Validate() error {
 		if strings.ContainsRune(s, '\'') {
 			return false
 		}
-		if strings.ContainsRune(s, '.') {
-			return false
-		}
 		return true
 	}
 


### PR DESCRIPTION
  - modify validation on matadata values as they can have . char
  - fixes #144
  - fixes #98

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>