### PR TITLE
chore(plugins): use loginsight gem 1.0.0

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -95,12 +95,7 @@ RUN mkdir -p /fluentd/log /fluentd/etc /fluentd/plugins /usr/local/bundle/bin/ \
   && gem build fluent-plugin-google-cloud.gemspec \
   && gem install fluent-plugin-google-cloud-*.gem \
   && cd /fluentd \
-  && git clone https://github.com/Cryptophobia/fluent-plugin-vmware-loginsight.git fluent-plugin-vmware-loginsight \
-  && cd fluent-plugin-vmware-loginsight \
-  && gem build fluent-plugin-vmware-loginsight.gemspec \
-  && gem install fluent-plugin-vmware-loginsight-*.gem \
   && rm -rf /fluentd/fluent-plugin-google-cloud \
-  && rm -rf /fluentd/fluent-plugin-vmware-loginsight \
   && tdnf clean all \
   && gem sources --clear-all \
   && ln -s $(which fluentd) /usr/local/bundle/bin/fluentd \

--- a/base-image/Gemfile
+++ b/base-image/Gemfile
@@ -44,7 +44,7 @@ gem 'fluent-plugin-sumologic_output', "1.6.1"
 gem 'fluent-plugin-systemd', "1.0.2"
 gem 'fluent-plugin-uri-parser', "0.3.0"
 gem 'fluent-plugin-verticajson', "0.0.6"
-#gem 'fluent-plugin-vmware-loginsight', :git => "https://github.com/Cryptophobia/fluent-plugin-vmware-loginsight.git"
+gem 'fluent-plugin-vmware-loginsight', "1.0.0"
 gem 'fluent-plugin-vmware-log-intelligence', "2.0.6"
 # fluent-plugin-mysqlslowquery is dependency for fluent-plugin-vmware-log-intelligence
 gem 'fluent-plugin-mysqlslowquery', "0.0.9"


### PR DESCRIPTION
  - use 1.0.0 vmware-loginsight gem from ruby gems
  - remove fork gem building for loginsight gem
  - this PR has merged https://github.com/vmware/fluent-plugin-vmware-loginsight/pull/24

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>