### PR TITLE
fix(reloader): fix ctx.Namespace typo

### DIFF
--- a/config-reloader/generator/generator.go
+++ b/config-reloader/generator/generator.go
@@ -280,7 +280,7 @@ func (g *Generator) makeValidationTrailer(ns *datasource.NamespaceConfig, genCtx
 
 func (g *Generator) makeContext(ns *datasource.NamespaceConfig, genCtx *processors.GenerationContext) *processors.ProcessorContext {
 	ctx := &processors.ProcessorContext{
-		Namepsace:         ns.Name,
+		Namespace:         ns.Name,
 		NamespaceLabels:   ns.Labels,
 		AllowFile:         g.cfg.AllowFile,
 		DeploymentID:      g.cfg.ID,

--- a/config-reloader/processors/destinations.go
+++ b/config-reloader/processors/destinations.go
@@ -20,7 +20,7 @@ type fixDestinations struct {
 }
 
 func makeSafeBufferPath(ctx *ProcessorContext, origBufPath string) string {
-	return fmt.Sprintf("/var/log/kfo-%s-%s-%s.buf", util.MakeFluentdSafeName(ctx.DeploymentID), ctx.Namepsace, util.Hash("", origBufPath))
+	return fmt.Sprintf("/var/log/kfo-%s-%s-%s.buf", util.MakeFluentdSafeName(ctx.DeploymentID), ctx.Namespace, util.Hash("", origBufPath))
 }
 
 func prohibitSources(d *fluentd.Directive, ctx *ProcessorContext) error {

--- a/config-reloader/processors/destinations_test.go
+++ b/config-reloader/processors/destinations_test.go
@@ -49,7 +49,7 @@ func TestDestinationsRewriteBufferPath(t *testing.T) {
 	fmt.Printf("Original:\n%s", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 	}
 	fragment, err = Process(fragment, ctx, &fixDestinations{})
 	assert.Nil(t, err)
@@ -67,7 +67,7 @@ func TestDestinationsRewriteBufferPath(t *testing.T) {
 
 func TestExpandBadConfig(t *testing.T) {
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 	}
 
 	list := []string{

--- a/config-reloader/processors/detect_exceptions_test.go
+++ b/config-reloader/processors/detect_exceptions_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRewrite(t *testing.T) {
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
@@ -55,7 +55,7 @@ func TestRewrite(t *testing.T) {
 func TestWithoutExceptions(t *testing.T) {
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
@@ -93,7 +93,7 @@ func TestWithoutExceptions(t *testing.T) {
 func TestWithExceptions(t *testing.T) {
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},

--- a/config-reloader/processors/expand_tags_test.go
+++ b/config-reloader/processors/expand_tags_test.go
@@ -27,7 +27,7 @@ func TestTagsExpandOk(t *testing.T) {
 		fmt.Printf("Original:\n%s", fragment)
 
 		ctx := &ProcessorContext{
-			Namepsace:         "monitoring",
+			Namespace:         "monitoring",
 			GenerationContext: &GenerationContext{},
 			AllowTagExpansion: true,
 		}
@@ -70,7 +70,7 @@ func TestNestedTagsExpandOk(t *testing.T) {
 	fmt.Printf("Original:\n%s", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace:         "monitoring",
+		Namespace:         "monitoring",
 		GenerationContext: &GenerationContext{},
 		AllowTagExpansion: true,
 	}
@@ -96,7 +96,7 @@ func TestNestedTagsExpandOk(t *testing.T) {
 func TestTagsExpandBadConfig(t *testing.T) {
 
 	ctx := &ProcessorContext{
-		Namepsace:         "monitoring",
+		Namespace:         "monitoring",
 		AllowTagExpansion: true,
 	}
 

--- a/config-reloader/processors/extract_plugins_test.go
+++ b/config-reloader/processors/extract_plugins_test.go
@@ -84,7 +84,7 @@ func TestExpandPlugins(t *testing.T) {
 
 	ctx := &ProcessorContext{
 		GenerationContext: g,
-		Namepsace:         "unit-test",
+		Namespace:         "unit-test",
 		DeploymentID:      "whatever",
 	}
 
@@ -146,7 +146,7 @@ func TestNothingToExpand(t *testing.T) {
 
 	ctx := &ProcessorContext{
 		GenerationContext: g,
-		Namepsace:         "unit-test",
+		Namespace:         "unit-test",
 		DeploymentID:      "whatever",
 	}
 
@@ -228,7 +228,7 @@ func TestExpandPluginsInCopyStore(t *testing.T) {
 
 	ctx := &ProcessorContext{
 		GenerationContext: g,
-		Namepsace:         "unit-test",
+		Namespace:         "unit-test",
 		DeploymentID:      "whatever",
 	}
 

--- a/config-reloader/processors/labels.go
+++ b/config-reloader/processors/labels.go
@@ -199,7 +199,7 @@ func (p *expandLabelsMacroState) Process(input fluentd.Fragment) (fluentd.Fragme
 			return nil
 		}
 
-		d.Tag = makeTagFromFilter(ctx.Namepsace, sortedLabelNames, labelNames)
+		d.Tag = makeTagFromFilter(ctx.Namespace, sortedLabelNames, labelNames)
 		ctx.GenerationContext.augmentTag(d)
 		return nil
 	}
@@ -210,7 +210,7 @@ func (p *expandLabelsMacroState) Process(input fluentd.Fragment) (fluentd.Fragme
 		Pattern string
 		Labels  []string
 	}{
-		fmt.Sprintf("kube.%s.*.*", p.Context.Namepsace),
+		fmt.Sprintf("kube.%s.*.*", p.Context.Namespace),
 		sortedLabelNames,
 	}
 	writer := &bytes.Buffer{}

--- a/config-reloader/processors/labels_test.go
+++ b/config-reloader/processors/labels_test.go
@@ -81,7 +81,7 @@ func TestLabelNoLabels(t *testing.T) {
 	fmt.Printf("Original:\n%s\n", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
@@ -114,7 +114,7 @@ func TestLabelWithLabels(t *testing.T) {
 	fmt.Printf("Original:\n%s\n", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
@@ -190,7 +190,7 @@ func TestLabelWithLabelsAndElse(t *testing.T) {
 	fmt.Printf("Original:\n%s\n", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
@@ -224,7 +224,7 @@ func TestLabelWithLabelsAndContainer(t *testing.T) {
 	fmt.Printf("Original:\n%s\n", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},

--- a/config-reloader/processors/mounted_file.go
+++ b/config-reloader/processors/mounted_file.go
@@ -118,7 +118,7 @@ func (state *mountedFileState) convertToFragement(cf *ContainerFile) fluentd.Fra
 
 				hostPath := state.makeHostPath(cf, hm, mc)
 				pos := util.Hash(state.Context.DeploymentID, fmt.Sprintf("%s-%s-%s", mc.PodID, mc.Name, hostPath))
-				tag := fmt.Sprintf("kube.%s.%s.%s-%s", state.Context.Namepsace, mc.PodName, mc.Name, pos)
+				tag := fmt.Sprintf("kube.%s.%s.%s-%s", state.Context.Namespace, mc.PodName, mc.Name, pos)
 				dir.SetParam("path", hostPath)
 				dir.SetParam("read_from_head", "true")
 				dir.SetParam("tag", tag)
@@ -164,7 +164,7 @@ func (state *mountedFileState) makeAttachK8sMetadataDirective(tag string, mc *da
 	fmt.Fprintf(buf, "record['kubernetes']=%s; ", util.ToRubyMapLiteral(map[string]string{
 		"container_name":  mc.Name,
 		"container_image": mc.Image,
-		"namespace_name":  state.Context.Namepsace,
+		"namespace_name":  state.Context.Namespace,
 		"pod_name":        mc.PodName,
 		"pod_id":          mc.PodID,
 		"host":            mc.NodeName,

--- a/config-reloader/processors/mounted_file_test.go
+++ b/config-reloader/processors/mounted_file_test.go
@@ -33,7 +33,7 @@ func TestMountedFileRemovedAfterProcessing(t *testing.T) {
 	fmt.Printf("Original: %s", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 	}
 
 	processor := &mountedFileState{}
@@ -202,7 +202,7 @@ func TestConvertToFragment(t *testing.T) {
 	}
 
 	ctx := &ProcessorContext{
-		Namepsace:   "monitoring",
+		Namespace:   "monitoring",
 		KubeletRoot: "/kubelet-root",
 		MiniContainers: []*datasource.MiniContainer{
 			c1,
@@ -318,7 +318,7 @@ func TestProcessMountedFile(t *testing.T) {
 	}
 
 	ctx := &ProcessorContext{
-		Namepsace:   "monitoring",
+		Namespace:   "monitoring",
 		KubeletRoot: "/kubelet-root",
 		MiniContainers: []*datasource.MiniContainer{
 			c1,

--- a/config-reloader/processors/processor.go
+++ b/config-reloader/processors/processor.go
@@ -37,7 +37,7 @@ func (g *GenerationContext) augmentTag(d *fluentd.Directive) {
 // ProcessorContext is how a processor gets an environment to operate in.
 // It is both the model and the workspace of a processor.
 type ProcessorContext struct {
-	Namepsace         string
+	Namespace         string
 	NamespaceLabels   map[string]string
 	AllowFile         bool
 	DeploymentID      string

--- a/config-reloader/processors/processor_test.go
+++ b/config-reloader/processors/processor_test.go
@@ -38,7 +38,7 @@ func Test_callForEveryDirective(t *testing.T) {
 	fmt.Printf("Original:\n%s", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "test",
+		Namespace: "test",
 	}
 	count := 0
 	inc := func(*fluentd.Directive, *ProcessorContext) error {

--- a/config-reloader/processors/relabel.go
+++ b/config-reloader/processors/relabel.go
@@ -23,7 +23,7 @@ func normalizeLabelName(ctx *ProcessorContext, label string) string {
 
 	return fmt.Sprintf("@%s-%s",
 		util.MakeFluentdSafeName(label),
-		util.Hash(ctx.Namepsace, label))
+		util.Hash(ctx.Namespace, label))
 }
 
 func (p *rewriteLabelsState) Process(input fluentd.Fragment) (fluentd.Fragment, error) {

--- a/config-reloader/processors/relabel_test.go
+++ b/config-reloader/processors/relabel_test.go
@@ -34,7 +34,7 @@ func TestParseConfigWithBadLabels(t *testing.T) {
 	}
 
 	ctx := &ProcessorContext{
-		Namepsace: "demo",
+		Namespace: "demo",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
@@ -58,7 +58,7 @@ func TestParseConfigWithGoodLabels(t *testing.T) {
 		`
 
 	ctx := &ProcessorContext{
-		Namepsace: "demo",
+		Namespace: "demo",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
@@ -94,7 +94,7 @@ func TestLabelsAreRewritten(t *testing.T) {
 	fmt.Printf("Original:\n%s\n", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
@@ -151,7 +151,7 @@ func TestCopyPluginLabelsAreRewritten(t *testing.T) {
 	fmt.Printf("Original:\n%s\n", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
@@ -201,7 +201,7 @@ func TestLabelWithLabelsAndRelabelsAndElse(t *testing.T) {
 	fmt.Printf("Original:\n%s\n", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "demo",
+		Namespace: "demo",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},
@@ -237,7 +237,7 @@ func TestNastyRegex(t *testing.T) {
 	fmt.Printf("Original:\n%s\n", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace: "demo",
+		Namespace: "demo",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},

--- a/config-reloader/processors/share.go
+++ b/config-reloader/processors/share.go
@@ -83,7 +83,7 @@ func (p *shareLogsState) Prepare(input fluentd.Fragment) (fluentd.Fragment, erro
 			return nil
 		}
 
-		bridge := makeBridgeName(sourceNs, p.Context.Namepsace)
+		bridge := makeBridgeName(sourceNs, p.Context.Namespace)
 		p.Context.GenerationContext.ReferencedBridges[bridge] = true
 		return nil
 	}
@@ -122,7 +122,7 @@ func (p *shareLogsState) Process(input fluentd.Fragment) (fluentd.Fragment, erro
 			if destNs == "" {
 				return fmt.Errorf("@type share required a with_namespace parameter")
 			}
-			bridge := makeBridgeName(p.Context.Namepsace, destNs)
+			bridge := makeBridgeName(p.Context.Namespace, destNs)
 
 			// only retain @relabel stores when the bridges are being referenced
 			if _, ok := p.Context.GenerationContext.ReferencedBridges[bridge]; ok {
@@ -155,10 +155,10 @@ func (p *shareLogsState) Process(input fluentd.Fragment) (fluentd.Fragment, erro
 			return nil
 		}
 
-		bridge := makeBridgeName(sourceNs, p.Context.Namepsace)
+		bridge := makeBridgeName(sourceNs, p.Context.Namespace)
 		d.Tag = bridge
 
-		fragment, err := makeRewriteTagFragment(sourceNs, p.Context.Namepsace)
+		fragment, err := makeRewriteTagFragment(sourceNs, p.Context.Namespace)
 		if err != nil {
 			// or just panic??
 			return err
@@ -182,7 +182,7 @@ func (p *shareLogsState) GetValidationTrailer(directives fluentd.Fragment) fluen
 	res := fluentd.Fragment{}
 
 	for k := range p.Context.GenerationContext.ReferencedBridges {
-		if strings.HasPrefix(k, fmt.Sprintf("@bridge-%s__", p.Context.Namepsace)) {
+		if strings.HasPrefix(k, fmt.Sprintf("@bridge-%s__", p.Context.Namespace)) {
 			dir := &fluentd.Directive{
 				Name: "label",
 				Tag:  k,

--- a/config-reloader/processors/share_test.go
+++ b/config-reloader/processors/share_test.go
@@ -88,7 +88,7 @@ func TestProcessShareDirectiveFromReceivingNs(t *testing.T) {
 	}
 
 	ctx := &ProcessorContext{
-		Namepsace:         "dest-ns",
+		Namespace:         "dest-ns",
 		GenerationContext: gen,
 	}
 
@@ -134,7 +134,7 @@ func TestProcessShareDirectiveFromPublishigNs(t *testing.T) {
 	}
 
 	ctx := &ProcessorContext{
-		Namepsace:         "source-ns",
+		Namespace:         "source-ns",
 		GenerationContext: gen,
 	}
 
@@ -174,7 +174,7 @@ func TestProcessShareDirectiveCollectBridges(t *testing.T) {
 	}
 
 	ctx := &ProcessorContext{
-		Namepsace:         "dest-ns",
+		Namespace:         "dest-ns",
 		GenerationContext: gen,
 	}
 

--- a/config-reloader/processors/thisns.go
+++ b/config-reloader/processors/thisns.go
@@ -20,7 +20,7 @@ type expandThisnsMacroState struct {
 
 func (p *expandThisnsMacroState) Process(input fluentd.Fragment) (fluentd.Fragment, error) {
 	f := func(d *fluentd.Directive, ctx *ProcessorContext) error {
-		namespace := ctx.Namepsace
+		namespace := ctx.Namespace
 
 		if d.Name != "match" &&
 			d.Name != "filter" {

--- a/config-reloader/processors/thisns_test.go
+++ b/config-reloader/processors/thisns_test.go
@@ -54,7 +54,7 @@ func TestThisnsExpandOk(t *testing.T) {
 	fmt.Printf("Original:\n%s", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace:         "monitoring",
+		Namespace:         "monitoring",
 		GenerationContext: &GenerationContext{},
 	}
 	fragment, err = Process(fragment, ctx, &expandThisnsMacroState{})
@@ -76,7 +76,7 @@ func TestThisnsExpandOk(t *testing.T) {
 func TestThisnsExpandBadConfig(t *testing.T) {
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 	}
 
 	list := []string{

--- a/config-reloader/processors/unique_rewrite_tag.go
+++ b/config-reloader/processors/unique_rewrite_tag.go
@@ -36,7 +36,7 @@ func (p *uniqueRewriteTagState) Process(input fluentd.Fragment) (fluentd.Fragmen
 				return fmt.Errorf("retag plugin does not yet support the ${tag_parts[n]} and __TAG_PARTS[n]__ placeholders")
 			}
 
-			targetTag := p.createUniqueTag(tagParam, ctx.Namepsace)
+			targetTag := p.createUniqueTag(tagParam, ctx.Namespace)
 
 			rule.SetParam("tag", targetTag)
 		}
@@ -62,7 +62,7 @@ func (p *uniqueRewriteTagState) Process(input fluentd.Fragment) (fluentd.Fragmen
 
 		targetTag := d.Tag[len(macroUniqueTag)+1 : len(d.Tag)-1]
 
-		d.Tag = p.createUniqueTag(targetTag, ctx.Namepsace)
+		d.Tag = p.createUniqueTag(targetTag, ctx.Namespace)
 		ctx.GenerationContext.augmentTag(d)
 
 		return nil

--- a/config-reloader/processors/unique_rewrite_tag_test.go
+++ b/config-reloader/processors/unique_rewrite_tag_test.go
@@ -45,7 +45,7 @@ func TestTagsRewrittenOk(t *testing.T) {
 	fmt.Printf("Original:\n%s", fragment)
 
 	ctx := &ProcessorContext{
-		Namepsace:         "monitoring",
+		Namespace:         "monitoring",
 		GenerationContext: &GenerationContext{},
 	}
 	fragment, err = Process(fragment, ctx, &uniqueRewriteTagState{})
@@ -77,7 +77,7 @@ func TestTagsRewrittenOk(t *testing.T) {
 func TestRewriteTagsBadConfig(t *testing.T) {
 
 	ctx := &ProcessorContext{
-		Namepsace: "monitoring",
+		Namespace: "monitoring",
 		GenerationContext: &GenerationContext{
 			ReferencedBridges: map[string]bool{},
 		},


### PR DESCRIPTION
 - fix the ctx.Namespace typo in ProcessorContext

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>