### PR TITLE
Fix typo in values.yaml

### DIFF
--- a/charts/log-router/values.yaml
+++ b/charts/log-router/values.yaml
@@ -31,7 +31,7 @@ image:
 
 
 logLevel: debug
-fluentdLoglevel: debug
+fluentdLogLevel: debug
 interval: 45
 kubeletRoot: /var/lib/kubelet
 


### PR DESCRIPTION
Typo in values.yaml `fluentdLog(L/l)evel` causes reloader container to fail:

```time="2021-04-21T16:11:02Z" level=info msg="Version: v1.14.0-2-ga41ec00"
time="2021-04-21T16:11:02Z" level=info msg="Config: &{Master: KubeConfig: FluentdRPCPort:24444 TemplatesDir:/templates OutputDir:/fluentd/etc LogLevel:debug FluentdLogLevel: AnnotConfigmapName:logging.csp.vmware.com/fluentd-configmap AnnotStatus:logging.csp.vmware.com/fluentd-status DefaultConfigmapName:fluentd-config IntervalSeconds:45 Datasource:default CRDMigrationMode:false FsDatasourceDir: AllowFile:false ID:kfo-log-router FluentdValidateCommand:/usr/local/bundle/bin/fluentd -p /fluentd/plugins MetaKey: MetaValues: LabelSelector: KubeletRoot:/var/lib/kubelet Namespaces:[] PrometheusEnabled:false MetricsPort:9000 AllowTagExpansion:false AdminNamespace:kube-system level:0 ParsedMetaValues:map[] ParsedLabelSelector: ExecTimeoutSeconds:30}"
time="2021-04-21T16:11:02Z" level=fatal msg="Config validation failed: failed to parse fluentd log level: not a valid Fluentd log Level: \"\""
```

```...
  reloader:                                                                                                                                   
    Container ID:  docker://ae2c058cc019a944ed6937141a882577d70435713549e46ff6c2a45a109b3a72                                                  
    Image:         vmware/kube-fluentd-operator:latest                                                                                        
    Image ID:      docker-pullable://vmware/kube-fluentd-operator@sha256:840e200fde52487e7543c002a8fb6261b8000230507e58468fb1a6906aed253b     
    Port:          <none>                                                                                                                     
    Host Port:     <none>                                                                                                                     
    Command:                                                                                                                                  
      /bin/config-reloader                                                                                                                    
      --datasource=default                                                                                                                    
      --default-configmap=fluentd-config                                                                                                      
      --interval=45                                                                                                                           
      --log-level=debug                                                                                                                                                                                                                                                                     
>>>      --fluentd-loglevel=                                                                                                                                                                                                                                                                   
      --output-dir=/fluentd/etc                                                                                                                                                                                                                                                             
...                 
```