### PR TITLE
fix(kubernetes.conf): set read_from_head to false

### DIFF
--- a/config-reloader/templates/kubernetes.conf
+++ b/config-reloader/templates/kubernetes.conf
@@ -7,7 +7,7 @@
   path /var/log/containers/*.log
   pos_file /var/log/{{.ID}}-fluentd-containers.log.pos
   tag kubernetes.*
-  read_from_head true
+  read_from_head false
   <parse>
     @type multiline
     # cri-o


### PR DESCRIPTION
 - set `read_from_head` to `false` since k8s clusters do graceful log rotation
 - in huge clusters, there is no need to read_from_head
 - KFO takes a long time to read files from the beginning and still sends duplicate log lines
 - since we are using .pos files and names do not collide, this should be safe

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>