### PR TITLE
Revert "fix(kubernetes.conf): set read_from_head to false"

### DIFF
--- a/config-reloader/templates/kubernetes.conf
+++ b/config-reloader/templates/kubernetes.conf
@@ -7,7 +7,7 @@
   path /var/log/containers/*.log
   pos_file /var/log/{{.ID}}-fluentd-containers.log.pos
   tag kubernetes.*
-  read_from_head false
+  read_from_head true
   <parse>
     @type multiline
     # cri-o


### PR DESCRIPTION
 - this reverts commit d92d41a2b4692c91af067c7d1cf9d05b556e205e.
 - turns out setting `read_from_head true` is right behavior

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>