### PR TITLE
chore(fluentd): upgrade fluentd v1.13.1 and gems

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -46,10 +46,12 @@ RUN git clone git://github.com/rbenv/ruby-build.git $RUBY_PATH/plugins/ruby-buil
     && gem update --system \
     && gem install bundler -v '>= 2.2.21' --default \
     && gem install rexml -v '>= 3.2.5' --default \
+    && gem install rdoc -v '>= 6.3.1' --default \
     && bundler install \
     && gem uninstall rake -v 13.0.3 \
     && gem uninstall bigdecimal \
-    && rm -rf $RUBY_PATH/lib/ruby/gems/2.7.0/specifications/default/rexml-3.2.3.1.gemspec
+    && rm -rf $RUBY_PATH/lib/ruby/gems/2.7.0/specifications/default/rexml-3.2.3.1.gemspec \
+    && rm -rf $RUBY_PATH/lib/ruby/gems/2.7.0/specifications/default/rdoc-6.2.1.gemspec
 
 FROM photon:4.0
 ARG RUBY_PATH

--- a/base-image/Gemfile
+++ b/base-image/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # pin fluentd, probably a good idea to pin all gems
-gem "fluentd", "~> 1.13.0"
+gem "fluentd", "~> 1.13.1"
 
 gem 'ffi', "1.15.1"
 gem 'fluent-plugin-amqp', "0.14.0"

--- a/base-image/Gemfile.lock
+++ b/base-image/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3.2)
-      activesupport (= 6.1.3.2)
-    activesupport (6.1.3.2)
+    activemodel (6.1.4)
+      activesupport (= 6.1.4)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -15,7 +15,7 @@ GEM
     amq-protocol (2.3.2)
     attr_required (1.0.1)
     aws-eventstream (1.1.1)
-    aws-partitions (1.470.0)
+    aws-partitions (1.472.0)
     aws-sdk-cloudwatchlogs (1.41.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
@@ -46,7 +46,7 @@ GEM
       rest-client
     bindata (2.4.10)
     bson (4.12.1)
-    bunny (2.18.0)
+    bunny (2.19.0)
       amq-protocol (~> 2.3, >= 2.3.1)
       sorted_set (~> 1, >= 1.0.2)
     concurrent-ruby (1.1.9)
@@ -68,7 +68,7 @@ GEM
       faraday (~> 1)
       multi_json
     excon (0.82.0)
-    faraday (1.4.2)
+    faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -219,7 +219,7 @@ GEM
       myslog (~> 0.0)
     fluent-plugin-vmware-loginsight (1.0.0)
       fluentd (>= 0.14.10, < 2)
-    fluentd (1.13.0)
+    fluentd (1.13.1)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -402,7 +402,7 @@ DEPENDENCIES
   fluent-plugin-verticajson (= 0.0.6)
   fluent-plugin-vmware-log-intelligence (= 2.0.6)
   fluent-plugin-vmware-loginsight (= 1.0.0)
-  fluentd (~> 1.13.0)
+  fluentd (~> 1.13.1)
   gelf (= 3.1.0)
   kubeclient (~> 4.9.0, < 5.0.0)
   logfmt (= 0.0.9)


### PR DESCRIPTION
 - upgrade `fluentd` to new minor release [v1.13.1](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1131)
 - upgrade other non-pegged gems in Gemfile.lock
 - upgrade `rdoc` to `>= 6.3.1` for CVE

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>