### PR TITLE
fix: use strategic merge patch for namespace

### DIFF
--- a/config-reloader/datasource/kube_informer.go
+++ b/config-reloader/datasource/kube_informer.go
@@ -109,7 +109,7 @@ func (d *kubeInformerConnection) UpdateStatus(namespace string, status string) {
 	}
 
 	body, _ := json.Marshal(&patch)
-	_, err := d.client.CoreV1().Namespaces().Patch(namespace, types.MergePatchType, body)
+	_, err := d.client.CoreV1().Namespaces().Patch(namespace, types.StrategicMergePatchType, body)
 
 	logrus.Debugf("Saving status: %+v, %+v", patch, err)
 	if err != nil {


### PR DESCRIPTION
 - to use stategic merge patch for namespace annotations

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>