### PR TITLE
feat(charts): bump up chart version to 0.4.0

### DIFF
--- a/charts/log-router/Chart.yaml
+++ b/charts/log-router/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 description: Distribution of Fluentd as K8S daemonset
 name: log-router
-version: 0.3.8
+version: 0.4.0
 home: https://github.com/vmware/kube-fluentd-operator
 sources:
   - https://github.com/vmware/kube-fluentd-operator


### PR DESCRIPTION
 - bump up chart version to `0.4.0` because of chart changes

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>