### PR TITLE
fix(kubectl): add update to kubectl manifests

### DIFF
--- a/kubectl/manifests.yaml
+++ b/kubectl/manifests.yaml
@@ -30,7 +30,7 @@ rules:
     resources:
       - namespaces
     verbs:
-      - patch
+      - update
   - apiGroups: ["apiextensions.k8s.io"]
     resources:
       - customresourcedefinitions


### PR DESCRIPTION
 - closes #261
 - remove "patch" and add "update" on namespaces permissions
 - helm is backwards-compatibile, kubectl manifests do not need to be

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>