### PR TITLE
windows port

### DIFF
--- a/base-image/Dockerfile.windows
+++ b/base-image/Dockerfile.windows
@@ -1,0 +1,89 @@
+############ escape=`
+
+ARG WIN_TAG=ltsc2019
+
+FROM mcr.microsoft.com/windows/servercore:$WIN_TAG as ruby-base
+LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.13.1"
+
+
+# Do not split this into multiple RUN!
+# Docker creates a layer for every RUN-Statement
+RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+
+# Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
+# NOTE: For avoiding stalling with docker build on windows, we must use latest version of msys2.
+RUN choco install -y ruby --version=2.7.2.1 --params "'/InstallDir:C:\ruby27'" \
+    && MD C:\Users\ContainerUser\.gem \
+    && MD C:\fluentd \
+    && refreshenv \
+    && echo gem: --user-install --no-document >> c:/Users/ContainerUser/.gemrc \
+    && gem update --system 
+
+USER ContainerAdministrator
+RUN setx /m PATH "C:\Users\ContainerUser\.gem\bin;%PATH%" \
+ && setx /m GEM_HOME c:/Users/ContainerUser/.gem
+USER ContainerUser
+
+
+
+FROM ruby-base as ruby-build
+
+USER ContainerAdministrator
+RUN choco install -y msys2 --version 20210604.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\msys64'" \
+    && setx /m PATH "C:\msys64\usr\bin;%PATH%" \
+    && setx /m MSYS winsymlinks:nativestrict \
+    && ridk install 3 \
+    && mklink /J C:\msys64\fluentd C:\fluentd
+USER ContainerUser
+
+SHELL ["bash", "-lc"]
+RUN "echo 'PATH=$PATH:/mingw64/bin:/c/ruby27/bin:/c/users/containeruser/.gem/ruby/2.7.0/bin' >> /etc/profile.d/000-mingw64.sh \
+    && pacman -Suu --noconfirm && pacman -S --needed --noconfirm git \
+    "
+
+# RUN "pacman -Suu --noconfirm && pacman -S --needed --noconfirm git"
+
+COPY basegems/Gemfile /fluentd/Gemfile.basegems
+COPY basegems/Gemfile.lock /fluentd/Gemfile.basegems.lock
+
+COPY Gemfile /fluentd/Gemfile
+COPY Gemfile.lock /fluentd/Gemfile.lock
+
+RUN "\
+    gem install bundler:'>= 2.2.27' rexml:'>= 3.2.5' rdoc:'>= 6.3.2' json:'>= 2.5.1' webrick:'>= 1.7.0' bigdecimal \
+    && cd /fluentd \
+    && bundler config --global jobs 4 \
+    && bundler config set --global without \"development test\" \
+    && bundler config set --global cache_all 'false' \
+    && bundler install --no-cache --gemfile=Gemfile.basegems \
+    && bundler install --no-cache --gemfile=Gemfile \
+    && git clone https://github.com/Cryptophobia/fluent-plugin-google-cloud.git fluent-plugin-google-cloud \
+    && gem build -C fluent-plugin-google-cloud fluent-plugin-google-cloud.gemspec \
+    && gem install --no-document fluent-plugin-google-cloud/fluent-plugin-google-cloud-*.gem \
+    && git clone https://github.com/Cryptophobia/fluent-plugin-loggly.git fluent-plugin-loggly \
+    && gem build -C fluent-plugin-loggly fluent-plugin-loggly.gemspec \
+    && gem install fluent-plugin-loggly/fluent-plugin-loggly-*.gem \
+    && rm -rf $GEM_HOME/cache/* $GEM_HOME/doc/* \
+    "
+# RUN "cd /fluentd && bundle config list && du -h --max-depth 1 $GEM_HOME"
+
+FROM ruby-base as ruby-runtime
+COPY --from=ruby-build /Users/ContainerUser/.gem /Users/ContainerUser/.gem
+COPY plugins /etc/fluent-plugin
+
+USER ContainerAdministrator
+RUN tzutil /s UTC \
+    && (if not exist C:\etc\fluent-conf (MD C:\etc\fluent-conf)) \
+    && (if not exist C:\etc\fluent-plugin (MD C:\etc\fluent-plugin)) \
+    && (if not exist C:\var\run\secrets\kubernetes.io\serviceaccount (MD C:\var\run\secrets\kubernetes.io\serviceaccount)) \
+    && (if not exist C:\var\log (MD C:\var\log)) \
+    && (if not exist C:\var\lib\kubelet (MD C:\var\lib\kubelet))
+USER ContainerUser
+RUN powershell -Command "Invoke-WebRequest https://raw.githubusercontent.com/fluent/fluentd-kubernetes-daemonset/master/docker-image/v1.13/debian-elasticsearch7/plugins/parser_kubernetes.rb -OutFile C:\etc\fluent-plugin\parser_kubernetes.rb \
+  ; Invoke-WebRequest https://raw.githubusercontent.com/fluent/fluentd-kubernetes-daemonset/master/docker-image/v1.13/debian-elasticsearch7/plugins/parser_multiline_kubernetes.rb -OutFile C:\etc\fluent-plugin\parser_multiline_kubernetes.rb \
+  "
+
+COPY failsafe.conf /etc/fluent-conf/failsafe.conf
+COPY entrypoint.ps1 /entrypoint.ps1
+ENTRYPOINT ["powershell", "/entrypoint.ps1"]

--- a/base-image/Makefile
+++ b/base-image/Makefile
@@ -1,13 +1,23 @@
 # Copyright © 2018 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-IMAGE ?= vmware/base-fluentd-operator
-TAG ?= latest
+IMAGE            ?= vmware/base-fluentd-operator
+IMG_ARCH         ?= amd64
+WIN_TAG          ?=
+IMG_OS           ?= linux
+TAG              ?= $(IMG_ARCH)-$(IMG_OS)$(shell v='$(WIN_TAG)'; echo "$${v:+-}$${v:-}")
 
 .PHONY: test
+ttt:
+	echo $(TAG)
 
 build-image:
 	DOCKER_BUILDKIT=1 docker build -t $(IMAGE):$(TAG) .
+
+build-windows-image:
+	@echo Building $(IMAGE):$(TAG)
+	docker build --network "Default Switch" -f Dockerfile.windows --build-arg WIN_TAG=$(WIN_TAG) -t $(IMAGE):$(TAG) .
+
 
 shell:
 	docker run --entrypoint=/bin/bash \

--- a/base-image/entrypoint.ps1
+++ b/base-image/entrypoint.ps1
@@ -1,0 +1,25 @@
+$FLUENTD_CONF = if ($env:FLUENTD_CONF) { $env:FLUENTD_CONF } else { "fluent.conf" };
+$DEFAULT_FLUENT_CONF = "/etc/fluent-conf/${FLUENTD_CONF}";
+$FLUENTD_OPT = $env:FLUENTD_OPT
+
+echo "Using configuration: ${DEFAULT_FLUENT_CONF}"
+echo "With FLUENTD_OPT: ${FLUENTD_OPT}"
+
+$retries = if ($env:RETRIES) { $env:RETRIES } else { 60 };
+$ready = $false
+
+foreach ($attempt in 1..$retries) {
+    if (Test-Path -Path $DEFAULT_FLUENT_CONF -PathType Leaf) {
+        $ready = $true
+        break
+    }
+    echo "Waiting for config file to become available: $attempt of $retries"
+    Start-Sleep -Seconds 10
+}
+if ($ready -ne $true ) {return 1}
+echo "Found configuration file: ${DEFAULT_FLUENT_CONF}"
+$cmdline_args = "& fluentd", "-c", ${DEFAULT_FLUENT_CONF}, "-p", "/etc/fluent-plugin", $FLUENTD_OPT
+$cmdline = $cmdline_args -join ' '
+echo "cmdline $cmdline"
+Invoke-Expression $cmdline
+#& \fluentd.cmd -c ${DEFAULT_FLUENT_CONF} -p /etc/fluent/plugins $FLUENTD_OPT

--- a/charts/log-router/templates/_helpers.tpl
+++ b/charts/log-router/templates/_helpers.tpl
@@ -42,3 +42,115 @@ extensions/v1beta1
 apps/v1
 {{- end -}}
 {{- end -}}
+
+
+
+{{- define "node.kubeletRootPath" }}
+{{- if eq .Values.nodeProfileName "windows" }}
+{{- .Values.nodeProfile.kubeletRootPath | default "C:/var/lib/kubelet" -}}
+{{- else }}
+{{- .Values.nodeProfile.kubeletRootPath | default "/var/lib/kubelet" -}}
+{{- end }}
+{{- end }}
+
+
+
+{{- define "node.fluentConfMountPath" }}
+{{- if eq .Values.nodeProfileName "windows" }}
+{{- .Values.nodeProfile.fluentConfMountPath | default "C:/etc/fluent-conf" -}}
+{{- else }}
+{{- .Values.nodeProfile.fluentConfMountPath | default "/fluentd/etc" -}}
+{{- end }}
+{{- end }}
+
+
+{{- define "node.volumes" }}
+- name: fluentconf
+  emptyDir: {}
+{{- if eq .Values.nodeProfileName "windows" }}
+- name: var
+  hostPath:
+   path: {{ .Values.nodeProfile.varHostPath | default "C:/var" }}
+- name: varlibdocker
+  hostPath:
+   path: {{ .Values.nodeProfile.varLibDockerContainersHostPath | default "C:/ProgramData/docker" }}
+{{- else }}
+- name: kubeletroot
+  hostPath:
+   path: {{ .Values.nodeProfile.kubeletRootHostPath | default "/var/lib/kubelet" }}
+- name: varlog
+  hostPath:
+   path: {{ .Values.nodeProfile.varLogHostPath | default "/var/log" }}
+- name: varlibdockercontainers
+  hostPath:
+   path: {{ .Values.nodeProfile.varLibDockerContainersHostPath | default "/var/lib/docker/containers" }}
+{{- end }}
+{{- end }}
+
+
+{{- define "node.fluendVolumeMounts" }}
+- name: fluentconf
+  mountPath: {{ include "node.fluentConfMountPath" . }}
+{{- if eq .Values.nodeProfileName "windows" }}
+- name: var
+  mountPath: {{ .Values.nodeProfile.varMountPath | default "C:/var" }} 
+- name: varlibdocker
+  mountPath: {{ .Values.nodeProfile.varLibDockerContainersMountPath | default "C:/ProgramData/docker" }}
+  readOnly: true
+{{- else }}
+- name: kubeletroot
+  mountPath: {{ include "node.kubeletRootPath" . }}
+  readOnly: true
+- name: varlog
+  mountPath: {{ .Values.nodeProfile.varLogMountPath | default "/var/log" }}
+- name: varlibdockercontainers
+  mountPath: {{ .Values.nodeProfile.varLibDockerContainersMountPath | default "/var/lib/docker/containers" }}
+  readOnly: true
+{{- end }}
+{{- end }}
+
+
+{{- define "node.operatorVolumeMounts" }}
+- name: fluentconf
+{{- if eq .Values.nodeProfileName "windows" }}
+  mountPath: {{ .Values.nodeProfile.fluentConfMountPath | default "C:/etc/fluent-conf" }}
+{{- else }}
+  mountPath: {{ .Values.nodeProfile.fluentConfMountPath | default "/fluentd/etc" }}
+{{- end }}
+{{- end }}
+
+
+{{- define "node.operatorBinary" }}
+{{- if eq .Values.nodeProfileName "windows" }}
+{{- .Values.nodeProfile.operatorBinary | default "c:/bin/config-reloader.exe" -}}
+{{- else }}
+{{- .Values.nodeProfile.operatorBinary | default "/bin/config-reloader" -}}
+{{- end }}
+{{- end }}
+
+
+{{- define "node.fluentdBinary" }}
+{{- if eq .Values.nodeProfileName "windows" }}
+{{- .Values.nodeProfile.fluentdBinary | default "fluentd -p /etc/fluent-plugin" -}}
+{{- else }}
+{{- .Values.nodeProfile.fluentdBinary | default "/usr/local/bundle/bin/fluentd -p /fluentd/plugins" -}}
+{{- end }}
+{{- end }}
+
+{{- define "node.templatesDir" }}
+{{- if eq .Values.nodeProfileName "windows" }}
+{{- .Values.nodeProfile.templatesDir | default "C:/templates" -}}
+{{- else }}
+{{- .Values.nodeProfile.templatesDir | default "/templates" -}}
+{{- end }}
+{{- end }}
+
+{{- define "node.useSystemd" }}
+{{- if .Values.nodeProfile.useSystemd }}
+- {{ .Values.nodeProfile.useSystemd }}
+{{- else }}
+{{- if ne .Values.nodeProfileName "windows" }}
+- {{ "--use-systemd" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/log-router/templates/daemonset.yaml
+++ b/charts/log-router/templates/daemonset.yaml
@@ -63,16 +63,7 @@ spec:
             containerPort: 24231
           {{- end }}
           volumeMounts:
-          - name: fluentconf
-            mountPath: /fluentd/etc
-          - name: varlog
-            mountPath: /var/log
-          - name: kubeletroot
-            mountPath: "{{ .Values.kubeletRoot }}"
-            readOnly: true
-          - name: varlibdockercontainers
-            mountPath: /var/lib/docker/containers
-            readOnly: true
+{{- include "node.fluendVolumeMounts" . | indent 10 }}
 {{- if .Values.fluentd.extraVolumeMounts }}
 {{ toYaml .Values.fluentd.extraVolumeMounts | indent 10 }}
 {{- end }}
@@ -97,7 +88,7 @@ spec:
         {{- end }}
           {{- end }}
           command:
-          -  /bin/config-reloader
+          - {{ include "node.operatorBinary" . }}
           - --datasource={{ .Values.datasource }}
           {{- if .Values.crdMigrationMode }}
           - --crd-migration-mode
@@ -109,17 +100,17 @@ spec:
           {{- if not (empty .Values.bufferMountFolder) }}
           - --buffer-mount-folder={{ .Values.bufferMountFolder }}
           {{- end }}
-          - --output-dir=/fluentd/etc
-          - --templates-dir=/templates
+          - --output-dir={{ include "node.fluentConfMountPath" . }}
+          - --templates-dir={{ include "node.templatesDir" . }}
           - --id={{ template "fluentd-router.fullname" . }}
           - --fluentd-binary
           {{- if .Values.logRotate.enabled }}
-          - /usr/local/bundle/bin/fluentd -p /fluentd/plugins --log-rotate-age {{  .Values.logRotate.logRotateAge  }} --log-rotate-size {{  .Values.logRotate.logRotateSize | int }}
+          - {{ include "node.fluentdBinary" . }} --log-rotate-age {{  .Values.logRotate.logRotateAge  }} --log-rotate-size {{  .Values.logRotate.logRotateSize | int }}
           {{ else }}
-          - /usr/local/bundle/bin/fluentd -p /fluentd/plugins
+          - {{ include "node.fluentdBinary" . }}
           {{ end }}
           - --kubelet-root
-          - "{{ .Values.kubeletRoot }}"
+          - {{ include "node.kubeletRootPath" . }}
           {{- if .Values.meta.key }}
           - --meta-key={{ .Values.meta.key }}
           - --meta-values={{- range $k, $v := .Values.meta.values }}{{$k}}={{$v}},
@@ -143,9 +134,21 @@ spec:
           {{- if .Values.adminNamespace }}
           - --admin-namespace={{ .Values.adminNamespace }}
           {{- end }}
+          {{- if .Values.fluentdReloadPath }}
+          - --fluentd-reload-path={{ .Values.fluentdReloadPath }}
+          {{- end }}
+          {{- if .Values.execTimeout }}
+          - --exec-timeout={{ .Values.execTimeout }}
+          {{- end }}
+          {{- if .Values.statusAnnotation }}
+          - --status-annotation={{ .Values.statusAnnotation }}
+          {{- end }}
+          {{- if .Values.configmapAnnotation }}
+          - --annotation={{ .Values.configmapAnnotation }}
+          {{- end }}
+          {{ include "node.useSystemd" . | indent 10}}
           volumeMounts:
-          - name: fluentconf
-            mountPath: /fluentd/etc
+{{- include "node.operatorVolumeMounts" . | indent 10 }}
 {{- if .Values.reloader.extraVolumeMounts }}
 {{ toYaml .Values.reloader.extraVolumeMounts | indent 10 }}
 {{- end }}
@@ -160,17 +163,7 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end}}
       volumes:
-      - name: fluentconf
-        emptyDir: {}
-      - name: kubeletroot
-        hostPath:
-          path: "{{ .Values.kubeletRoot }}"
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
+{{- include "node.volumes" . | indent 6 }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 6 }}
 {{- end }}

--- a/charts/log-router/values.yaml
+++ b/charts/log-router/values.yaml
@@ -32,7 +32,10 @@ image:
 logLevel: debug
 fluentdLogLevel: debug
 interval: 45
-kubeletRoot: /var/lib/kubelet
+# Profile name for operator "linux" or "windows"
+nodeProfileName: "linux"
+# Profile settings. See templates\_helpers.tpl
+nodeProfile: {}
 # bufferMountFolder -- a folder inside /var/log to write all fluentd buffers to
 bufferMountFolder: ""
 

--- a/config-reloader/Dockerfile
+++ b/config-reloader/Dockerfile
@@ -1,6 +1,8 @@
 # Copyright © 2018 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+ARG ARCH=amd64
+ARG OS=linux
 # builder image
 FROM golang:1.16 as builder
 
@@ -14,7 +16,7 @@ RUN make in-docker-test
 RUN make build VERSION=$VERSION
 
 # always use the un-pushable image
-FROM vmware/base-fluentd-operator:latest
+FROM vmware/base-fluentd-operator:$ARCH-$OS
 
 COPY templates /templates
 COPY validate-from-dir.sh /bin/validate-from-dir.sh

--- a/config-reloader/Dockerfile.windows
+++ b/config-reloader/Dockerfile.windows
@@ -1,0 +1,35 @@
+# Copyright © 2018 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# builder image
+ARG WIN_TAG=ltsc2019
+ARG VERSION
+ARG ARCH=amd64
+ARG OS=windows
+
+FROM mcr.microsoft.com/windows/servercore:$WIN_TAG as reloader-builder
+
+RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+
+# Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
+# NOTE: For avoiding stalling with docker build on windows, we must use latest version of msys2.
+RUN choco install -y msys2 --version 20210604.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\msys64'" \
+    && choco install -y golang --version=1.16 \
+    && choco install -y mingw make git jq
+
+USER ContainerAdministrator
+RUN setx /m PATH "%PATH%;c:\msys64\usr\bin"
+USER ContainerUser
+# ENV PATH "%PATH%;C:\msys64\usr\bin"
+
+WORKDIR /go/src/github.com/vmware/kube-fluentd-operator/config-reloader
+COPY . .
+
+RUN make in-docker-test
+RUN make build VERSION=$VERSION
+
+# always use the un-pushable image
+FROM vmware/base-fluentd-operator:${ARCH}-${OS}-${WIN_TAG}
+
+COPY templates /templates
+COPY --from=reloader-builder /go/src/github.com/vmware/kube-fluentd-operator/config-reloader/config-reloader.exe /bin/config-reloader.exe

--- a/config-reloader/Makefile
+++ b/config-reloader/Makefile
@@ -2,9 +2,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 IMAGE            ?= vmware/kube-fluentd-operator
-TAG              ?= latest
 
 VERSION          ?= $(shell git describe --tags --always --dirty)
+
+IMG_ARCH         ?= amd64
+IMG_OS           ?= linux
+WIN_TAG          ?= 
+TAG              ?= $(IMG_ARCH)-$(IMG_OS)$(shell v='$(WIN_TAG)'; echo "$${v:+-}$${v:-}")-$(VERSION)
 BUILD_FLAGS      := -v
 LDFLAGS          := -X github.com/vmware/kube-fluentd-operator/config-reloader/config.Version=$(VERSION) -w -s
 
@@ -20,6 +24,9 @@ DEV_ENV_WORK_DIR := /go/src/${PKG}
 DEV_ENV_CMD      := docker run --rm -v ${CURRENT_DIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 
 .DEFAULT_GOAL    := build-image
+
+PUSHED_TAGS      := $(shell curl -s https://hub.docker.com/v2/repositories/$(IMAGE)/tags | jq -r '.results[].name | select(. | endswith("-$(VERSION)"))')
+PUSHED_IMAGES    := $(foreach tag,$(PUSHED_TAGS),$(IMAGE):$(tag))
 
 all: test build
 
@@ -69,10 +76,28 @@ clean:
 	rm -fr config-reloader pkg > /dev/null
 
 build-image:
-	docker build --build-arg VERSION=$(VERSION) -t $(IMAGE):$(TAG) .
+	docker build --build-arg VERSION=$(VERSION) --build-arg ARCH=$(IMG_ARCH) --build-arg OS=$(IMG_OS) -t $(IMAGE):$(TAG) .
+
+build-windows-image:
+	@echo Building $(IMAGE):$(TAG)
+	docker build -f Dockerfile.windows --build-arg VERSION=$(VERSION) --build-arg WIN_TAG=$(WIN_TAG) --build-arg ARCH=$(IMG_ARCH) --build-arg OS=$(IMG_OS) -t $(IMAGE):$(TAG) .
 
 push-image: build-image
 	docker push $(IMAGE):$(TAG)
+
+push-windows-image: build-windows-image
+	docker push $(IMAGE):$(TAG)
+
+pushed-images:
+	@echo $(PUSHED_IMAGES)
+
+docker-manifest:
+	@echo Creating manifest $(IMAGE):$(VERSION) with images [$(PUSHED_IMAGES)]
+	docker manifest create --amend $(IMAGE):$(VERSION) $(PUSHED_IMAGES)
+
+docker-latest-manifest:
+	@echo Creating manifest $(IMAGE):latest with images [$(PUSHED_IMAGES)]
+	docker manifest create --amend $(IMAGE):latest $(PUSHED_IMAGES)
 
 push-latest:
 	docker tag $(IMAGE):$(TAG) $(IMAGE):latest

--- a/config-reloader/config/config.go
+++ b/config-reloader/config/config.go
@@ -56,6 +56,8 @@ type Config struct {
 	ParsedMetaValues    map[string]string
 	ParsedLabelSelector labels.Set
 	ExecTimeoutSeconds  int
+	FluentdReloadPath   string
+	UseSystemd          bool
 }
 
 var defaultConfig = &Config{
@@ -78,6 +80,7 @@ var defaultConfig = &Config{
 	MetricsPort:          9000,
 	AdminNamespace:       "kube-system",
 	ExecTimeoutSeconds:   30,
+	FluentdReloadPath:    "/api/config.gracefulReload",
 }
 
 var reValidID = regexp.MustCompile("([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]")
@@ -251,6 +254,11 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("admin-namespace", "Configurations defined in this namespace are copied as is, without further processing. Virtual plugins can also be defined in this namespace").Default(defaultConfig.AdminNamespace).StringVar(&cfg.AdminNamespace)
 
 	app.Flag("exec-timeout", "Timeout duration (in seconds) for exec command during validation").Default(strconv.Itoa(defaultConfig.ExecTimeoutSeconds)).IntVar(&cfg.ExecTimeoutSeconds)
+
+	app.Flag("fluentd-reload-path", "RPC path used to reload config. Possible values: '/api/config.gracefulReload' (default), '/api/config.reload'").Default(defaultConfig.FluentdReloadPath).StringVar(&cfg.FluentdReloadPath)
+
+	app.Flag("use-systemd", "Use systemd configuration in fluent.conf").BoolVar(&cfg.UseSystemd)
+
 	_, err := app.Parse(args)
 
 	if err != nil {

--- a/config-reloader/controller/controller.go
+++ b/config-reloader/controller/controller.go
@@ -59,7 +59,7 @@ func New(ctx context.Context, cfg *config.Config) (*Controller, error) {
 		if err != nil {
 			return nil, err
 		}
-		reloader = fluentd.NewReloader(ctx, cfg.FluentdRPCPort)
+		reloader = fluentd.NewReloader(ctx, cfg.FluentdRPCPort, cfg.FluentdReloadPath)
 		up = NewOnDemandUpdater(ctx, updateChan)
 	}
 

--- a/config-reloader/fluentd/fake-fluentd.cmd
+++ b/config-reloader/fluentd/fake-fluentd.cmd
@@ -1,0 +1,1 @@
+@bash fake-fluentd.sh %*

--- a/config-reloader/fluentd/reloader.go
+++ b/config-reloader/fluentd/reloader.go
@@ -14,12 +14,14 @@ import (
 // Reloader sends a reload signal to fluentd
 type Reloader struct {
 	port int
+        path string
 }
 
 // NewReloader will notify on the given rpc port
-func NewReloader(ctx context.Context, port int) *Reloader {
+func NewReloader(ctx context.Context, port int, path string) *Reloader {
 	return &Reloader{
 		port: port,
+                path: path,
 	}
 }
 
@@ -29,7 +31,7 @@ func (r *Reloader) ReloadConfiguration() {
 		logrus.Infof("Not reloading fluentd (fake or filesystem datasource used)")
 		return
 	}
-	_, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/api/config.gracefulReload", r.port), "application/json", nil)
+	_, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d%s", r.port, r.path), "application/json", nil)
 
 	if err != nil {
 		logrus.Errorf("cannot notify fluentd: %+v", err)

--- a/config-reloader/fluentd/reloader_test.go
+++ b/config-reloader/fluentd/reloader_test.go
@@ -25,7 +25,7 @@ func TestReloaderCalls(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("req %+v", r)
-		if r.Method == "POST" && r.RequestURI == "/api/config.gracefulReload" {
+		if r.Method == "POST" && (r.RequestURI == "/api/config.gracefulReload" || r.RequestURI == "/api/config.reload") {
 			counter++
 		}
 	}
@@ -38,7 +38,7 @@ func TestReloaderCalls(t *testing.T) {
 	go server.ListenAndServe()
 	defer server.Close()
 
-	r := NewReloader(ctx, port)
+	r := NewReloader(ctx, port, "/api/config.gracefulReload")
 
 	var err error
 	for i := 10; i >= 0; i-- {

--- a/config-reloader/fluentd/validator_test.go
+++ b/config-reloader/fluentd/validator_test.go
@@ -7,11 +7,16 @@ import (
 	"context"
 	"testing"
 	"time"
-
+	"fmt"
+	"runtime"
 	"github.com/stretchr/testify/assert"
 )
 
-const validateCommand = "./fake-fluentd.sh -p plugins"
+var validateCommand = fmt.Sprintf("%s -p plugins", 
+	map[string]string{
+		"windows" : "fake-fluentd.cmd",
+		"linux" : "./fake-fluentd.sh",
+	}[runtime.GOOS])
 
 func TestValidConfigString(t *testing.T) {
 	ctx := context.Background()

--- a/config-reloader/generator/generator.go
+++ b/config-reloader/generator/generator.go
@@ -115,6 +115,7 @@ func (g *Generator) renderMainFile(ctx context.Context, mainFile string, outputD
 		FluentdLogLevel         string
 		BufferMountFolder       string
 		PreprocessingDirectives []string
+		UseSystemd              bool
 	}{}
 
 	if g.cfg.MetaKey != "" {
@@ -129,6 +130,7 @@ func (g *Generator) renderMainFile(ctx context.Context, mainFile string, outputD
 	if g.cfg.BufferMountFolder != "" {
 		model.BufferMountFolder = g.cfg.BufferMountFolder
 	}
+	model.UseSystemd = g.cfg.UseSystemd
 
 	genCtx := &processors.GenerationContext{
 		ReferencedBridges: map[string]bool{},

--- a/config-reloader/templates/fluent.conf
+++ b/config-reloader/templates/fluent.conf
@@ -14,7 +14,9 @@
 
 
 # OS-level services
+{{if .UseSystemd -}}
 @include systemd.conf
+{{- end }}
 
 # docker container logs
 @include kubernetes.conf


### PR DESCRIPTION
## This PR represent fluentd windows port

in order to run operator in heterogenous cluster (linux and windows nodes) one have to run two operator instances. One for linux and another for windows nodes.

## Instructions

The easiest way to build linux and windows images is to have windows desktop (win 10) PC
Of course you'll need Docker Desktop installed https://docs.docker.com/desktop/windows/install/.
Docker Desktop should be running in WSL2 mode https://docs.docker.com/desktop/windows/wsl/
to be able to build linxu and windows images you need to install 

* [Chocolatey] (https://chocolatey.org/install)
```
Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
```

* Open cmd.exe in elevated prompt, install git (we will use bash from git package), make, jq
```
choco install git make jq -y
```

* Open cmd.exe, cd to the project root. Execute
```
"%ProgramFiles%\Git\git-bash.exe" --cd=.
```

* Open Docker Desktop, check if it is running in "Linux containers" mode. Build linux base image and reloader images with following command:

```
make build-image
```

* Push linux image with `make push-image`


* Switch Docker Desktop to "Windows containers" mode. Build windows images (for each windows platform you want to support https://hub.docker.com/_/microsoft-windows-servercore)
  NOTE: you need to change WIN_TAG for each iteration. For example: WIN_TAG := {ltsc2019, 1909, 2004, 20H2, ltsc2022}

  * Build base image for windows container with following command

    ```
    make build-windows-image IMG_OS=windows WIN_TAG=ltsc2019
    ```
    NOTE: you need to build as many base images as many windows versions you want to support (changing WIN_TAG parameter. Possible values https://hub.docker.com/_/microsoft-windows-servercore)

  * Build operator image
    ```
    make build-windows-image IMG_ARCH=amd64 IMG_OS=windows WIN_TAG=ltsc2019
    ```
    NOTE: you need to build as many base images as many windows versions you want to support (changing WIN_TAG parameter. Possible values https://hub.docker.com/_/microsoft-windows-servercore)

  * Push each windows image with `make push-windows-image IMG_ARCH=amd64 IMG_OS=windows WIN_TAG=ltsc2019`

* After all use `make pushed-images` to view all pushed images for the current release version

* Prepare multi-arch manifest 
  * Execute `make docker-manifest` to create docker manifest and include all images for current release
  * Annotate each image with arch and os tags. I don't know how to automate this. For example
    ```
    IMAGE=vmware/kube-fluentd-operator
    VERSION=$(git describe --tags --always --dirty)

    # Annotate linux version
    docker manifest annotate $IMAGE:$VERSION $IMAGE:amd64-linux-$VERSION --arch amd64 --os linux
    # Annotate windows version
    docker manifest annotate $IMAGE:$VERSION $IMAGE:amd64-windows-ltsc2019-$VERSION --arch amd64 --os windows --os-version 10.0.17763.2114
    ```  
  * Push manifest to the registry
    ```
    docker manifest push -p $IMAGE:$VERSION
    ```
* The same needs to be done in order to support 'latest' tag:
```
make docker-latest-manifest
IMAGE=vmware/kube-fluentd-operator
VERSION=$(git describe --tags --always --dirty)
# Annotate linux version
docker manifest annotate $IMAGE:latest $IMAGE:amd64-linux-$VERSION --arch amd64 --os linux
# Annotate windows version
docker manifest annotate $IMAGE:latest $IMAGE:amd64-windows-ltsc2019-$VERSION --arch amd64 --os windows --os-version 10.0.17763.2114
docker manifest push -p $IMAGE:latest
```

You may check if all images are combined under single manifest on dockerhub.com site.
As an example: https://hub.docker.com/layers/168658076/maxsivkov/kube-fluentd-operator/latest/images/sha256-3da050dc7b041e9415a472e3e6c06c5835b65186aca8ac45d6b6952e2f12ad6a?context=repo