### PR TITLE
fix(relabel): process timeout_labels also

### DIFF
--- a/config-reloader/processors/labels_test.go
+++ b/config-reloader/processors/labels_test.go
@@ -38,6 +38,7 @@ func TestSafeLabel(t *testing.T) {
 	assert.Equal(t, "_abc_", safeLabelValue("-abc-"))
 	assert.Equal(t, "abc___", safeLabelValue("abc..."))
 	assert.Equal(t, "abc_def", safeLabelValue("abc.def"))
+	assert.Equal(t, "app_kubernetes_io/name=nginx_ingress", safeLabelValue("app.kubernetes.io/name=nginx-ingress"))
 }
 
 func TestLabelsParseNotOk(t *testing.T) {
@@ -55,6 +56,7 @@ func TestLabelsParseNotOk(t *testing.T) {
 		"$labels(a=*)",
 		"$labels(a=1, =2)",
 		"$labels(_container=)", // empty container name
+		"$labels(app.kubernetes.io/name=*)",
 	}
 
 	for _, tag := range inputs {

--- a/config-reloader/processors/relabel.go
+++ b/config-reloader/processors/relabel.go
@@ -15,6 +15,19 @@ type rewriteLabelsState struct {
 	BaseProcessorState
 }
 
+var validLabelDirectives = []string{"match", "store", "filter", "parse", "source"}
+var validLabelTypes = []string{"relabel", "null", "forward", "stdout", "copy", "kafka", "elasticsearch"}
+
+func contains(slice []string, item string) bool {
+	set := make(map[string]struct{}, len(slice))
+	for _, s := range slice {
+		set[s] = struct{}{}
+	}
+
+	_, ok := set[item]
+	return ok
+}
+
 func normalizeLabelName(ctx *ProcessorContext, label string) string {
 	if strings.HasPrefix(label, "@$") {
 		// cross dependency to the share.go processor
@@ -28,20 +41,34 @@ func normalizeLabelName(ctx *ProcessorContext, label string) string {
 
 func (p *rewriteLabelsState) Process(input fluentd.Fragment) (fluentd.Fragment, error) {
 	normalizeAllLabels := func(d *fluentd.Directive, ctx *ProcessorContext) error {
-		if d.Name != "match" && d.Name != "store" {
+		if !contains(validLabelDirectives, d.Name) {
 			return nil
 		}
 
-		if d.Type() != "relabel" {
+		// Process any timeout_labels since they are valid labels:
+		timeoutLabel := d.Param("timeout_label")
+		if timeoutLabel != "" {
+			if !strings.HasPrefix(timeoutLabel, "@") {
+				return fmt.Errorf("bad label name %s for timeout_label, must start with @", timeoutLabel)
+			}
+
+			d.SetParam("timeout_label", normalizeLabelName(ctx, timeoutLabel))
+		}
+
+		// Continue parsing normal @labels:
+		if !contains(validLabelTypes, d.Type()) {
 			return nil
 		}
 
 		labelName := d.Param("@label")
-		if !strings.HasPrefix(labelName, "@") {
-			return fmt.Errorf("bad label name: %s", labelName)
+		if labelName != "" {
+			if !strings.HasPrefix(labelName, "@") {
+				return fmt.Errorf("bad label name %s for @label, must start with @", labelName)
+			}
+
+			d.SetParam("@label", normalizeLabelName(ctx, labelName))
 		}
 
-		d.SetParam("@label", normalizeLabelName(ctx, labelName))
 		return nil
 	}
 

--- a/config-reloader/processors/relabel_test.go
+++ b/config-reloader/processors/relabel_test.go
@@ -21,12 +21,6 @@ func TestParseConfigWithBadLabels(t *testing.T) {
 		`
 		<match **>
 		 @type relabel
-		 # missing label name
-		</match>
-		`,
-		`
-		<match **>
-		 @type relabel
 		 @label hello
 		 # bad prefix
 		</match>
@@ -79,6 +73,11 @@ func TestLabelsAreRewritten(t *testing.T) {
 	  @label @prometheus
 	</match>
 
+	<filter **>
+	  @type concat
+	  timeout_label @prometheus
+	</filter>
+
 	<label @prometheus>
 	  <match **>
 		@type forward
@@ -107,11 +106,15 @@ func TestLabelsAreRewritten(t *testing.T) {
 	assert.Equal(t, "kube.monitoring.*.prometheus", lit.Tag)
 	assert.NotEqual(t, lit.Param("@label"), "@prometheus")
 
-	starstar := fragment[1]
+	timeoutLabel := fragment[1].Params["timeout_label"]
+	assert.Equal(t, timeoutLabel.Name, "timeout_label")
+	assert.NotEqual(t, timeoutLabel.Value, "@prometheus")
+
+	starstar := fragment[2]
 	assert.Equal(t, "label", starstar.Name)
 	assert.NotEqual(t, lit.Tag, "@prometheus")
 
-	match := fragment[1].Nested[0]
+	match := fragment[2].Nested[0]
 	assert.Equal(t, "**", match.Tag)
 }
 


### PR DESCRIPTION
 - write test for timeout_labels to protect from regression
 - add timeout_labels in relabel processor logic
 - add multiple other valid fluentd directives and types for relabel logic

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>