### PR TITLE
fix(reloader): revert to reload endpoint and info

### DIFF
--- a/config-reloader/fluentd/reloader.go
+++ b/config-reloader/fluentd/reloader.go
@@ -29,9 +29,9 @@ func (r *Reloader) ReloadConfiguration() {
 		logrus.Infof("Not reloading fluentd (fake or filesystem datasource used)")
 		return
 	}
-	_, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/api/config.gracefulReload", r.port), "application/json", nil)
+	_, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/api/config.reload", r.port), "application/json", nil)
 
 	if err != nil {
-		logrus.Errorf("cannot notify fluentd: %+v", err)
+		logrus.Infof("cannot notify fluentd: %+v", err)
 	}
 }

--- a/config-reloader/fluentd/reloader_test.go
+++ b/config-reloader/fluentd/reloader_test.go
@@ -25,7 +25,7 @@ func TestReloaderCalls(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("req %+v", r)
-		if r.Method == "POST" && r.RequestURI == "/api/config.gracefulReload" {
+		if r.Method == "POST" && r.RequestURI == "/api/config.reload" {
 			counter++
 		}
 	}


### PR DESCRIPTION
 - reverting #189
 - there are too many old plugins which do not support gracefulReload yet

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>