### PR TITLE
ref(datasource): ns discovery on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Also, users don't need to bother with setting the correct `stream` parameter. *k
 
 ### Reusing output plugin definitions (since v1.6.0)
 
-Sometimes you only have a few valid options for log sinks: a dedicated S3 bucket, the ELK stack you manage, etc. The only flexibility you're after is letting namespace owners filter and parse their logs. In such cases you can abstract over an output plugin configuration - basically reducing it to a simple name which can be referenced from any namespace. For example, let's assume you have an S3 bucket for a "test" environement and you use loggly for a "staging" environment. The first thing you do is define these two output in the *admin* namespace:
+Sometimes you only have a few valid options for log sinks: a dedicated S3 bucket, the ELK stack you manage, etc. The only flexibility you're after is letting namespace owners filter and parse their logs. In such cases you can abstract over an output plugin configuration - basically reducing it to a simple name which can be referenced from any namespace. For example, let's assume you have an S3 bucket for a "test" environment and you use loggly for a "staging" environment. The first thing you do is define these two output in the *admin* namespace:
 
 ```xml
 admin-ns.conf:

--- a/config-reloader/config/config.go
+++ b/config-reloader/config/config.go
@@ -96,7 +96,7 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.ExecTimeoutSeconds < 0 {
-		cfg.IntervalSeconds = 30
+		cfg.ExecTimeoutSeconds = 30
 	}
 
 	ll, err := logrus.ParseLevel(cfg.LogLevel)

--- a/config-reloader/datasource/kubedatasource/configmap.go
+++ b/config-reloader/datasource/kubedatasource/configmap.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/vmware/kube-fluentd-operator/config-reloader/config"
-
+	kfoListersV1beta1 "github.com/vmware/kube-fluentd-operator/config-reloader/datasource/kubedatasource/fluentdconfig/client/listers/logs.vdp.vmware.com/v1beta1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -65,6 +65,11 @@ func NewConfigMapDS(ctx context.Context, cfg *config.Config, factory informers.S
 	})
 
 	return cmDS, nil
+}
+
+// GetFdlist return nil for this mode because it does not use CRDs:
+func (c *ConfigMapDS) GetFdlist() kfoListersV1beta1.FluentdConfigLister {
+	return nil
 }
 
 // IsReady returns a boolean specifying whether the ConfigMapDS is ready

--- a/config-reloader/datasource/kubedatasource/kubedatasource.go
+++ b/config-reloader/datasource/kubedatasource/kubedatasource.go
@@ -2,6 +2,7 @@ package kubedatasource
 
 import (
 	"context"
+	kfoListersV1beta1 "github.com/vmware/kube-fluentd-operator/config-reloader/datasource/kubedatasource/fluentdconfig/client/listers/logs.vdp.vmware.com/v1beta1"
 )
 
 // KubeDS is an interface defining behavor for the Kubernetes Resources
@@ -9,4 +10,5 @@ import (
 type KubeDS interface {
 	GetFluentdConfig(ctx context.Context, namespace string) (string, error)
 	IsReady() bool
+	GetFdlist() kfoListersV1beta1.FluentdConfigLister
 }

--- a/config-reloader/datasource/kubedatasource/migrationmode.go
+++ b/config-reloader/datasource/kubedatasource/migrationmode.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/vmware/kube-fluentd-operator/config-reloader/config"
+	kfoListersV1beta1 "github.com/vmware/kube-fluentd-operator/config-reloader/datasource/kubedatasource/fluentdconfig/client/listers/logs.vdp.vmware.com/v1beta1"
 
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/rest"
@@ -54,4 +55,9 @@ func (m *MigrationModeDS) GetFluentdConfig(ctx context.Context, namespace string
 	}
 
 	return cmConfigs + "\n" + fdConfigs, nil
+}
+
+// GetFdlist return nil for this mode because it does not use CRDs:
+func (m *MigrationModeDS) GetFdlist() kfoListersV1beta1.FluentdConfigLister {
+	return nil
 }

--- a/config-reloader/fluentd/reloader.go
+++ b/config-reloader/fluentd/reloader.go
@@ -34,9 +34,7 @@ func (r *Reloader) ReloadConfiguration() {
 	resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/api/config.reload", r.port), "application/json", nil)
 	if err != nil {
 		logrus.Errorf("fluentd config.reload post request failed: %+v", err)
-	}
-
-	if resp.StatusCode != 200 {
+	} else if resp.StatusCode != 200 {
 		defer resp.Body.Close()
 		body, _ := ioutil.ReadAll(resp.Body)
 		logrus.Errorf("fluentd config.reload endpoint returned statuscode %v; response: %v", resp.StatusCode, string(body))

--- a/config-reloader/fluentd/validator.go
+++ b/config-reloader/fluentd/validator.go
@@ -81,7 +81,7 @@ func (v *validatorState) ValidateConfigExtremely(config string, namespace string
 
 	out, err := util.ExecAndGetOutput(v.command, v.timeout, args...)
 
-	// strip color stuf from fluentd output
+	// strip color stuff from fluentd output
 	out = strings.TrimFunc(out, func(r rune) bool {
 		return !unicode.IsPrint(r)
 	})


### PR DESCRIPTION
 - on startup discover only namespaces that have CRDs or configmaps
 - resolves #222
 - extend interface for kubedatasource informers
 - attach `fluentdconfigDSLister` in `kubeInformerConnection`
 - init factory informer for configmaps
 - add factory informer for fluentdconfig CRDs

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>