### PR TITLE
fix(reloader): move back to config.gracefulReload

### DIFF
--- a/config-reloader/fluentd/reloader.go
+++ b/config-reloader/fluentd/reloader.go
@@ -31,7 +31,7 @@ func (r *Reloader) ReloadConfiguration() {
 		return
 	}
 
-	resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/api/config.reload", r.port), "application/json", nil)
+	resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/api/config.gracefulReload", r.port), "application/json", nil)
 	if err != nil {
 		logrus.Errorf("fluentd config.reload post request failed: %+v", err)
 	} else if resp.StatusCode != 200 {

--- a/config-reloader/fluentd/reloader_test.go
+++ b/config-reloader/fluentd/reloader_test.go
@@ -25,7 +25,7 @@ func TestReloaderCalls(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("req %+v", r)
-		if r.Method == "POST" && r.RequestURI == "/api/config.reload" {
+		if r.Method == "POST" && r.RequestURI == "/api/config.gracefulReload" {
 			counter++
 		}
 	}


### PR DESCRIPTION
 - we will not touch this anymore
 - `/api/config.gracefulReload` is recommended way to reload by fluentd since v1.9.0
 - ask @alex-vmw if you have any doubts...

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>