### PR TITLE
fix: react to pod events to regen preprocess conf

### DIFF
--- a/config-reloader/datasource/fake.go
+++ b/config-reloader/datasource/fake.go
@@ -25,7 +25,7 @@ var template = `
 `
 
 type fakeDatasource struct {
-	hashes map[string]string
+	confHashes map[string]string
 }
 
 func makeFakeConfig(namespace string) string {
@@ -59,7 +59,7 @@ func (d *fakeDatasource) GetNamespaces(ctx context.Context) ([]*NamespaceConfig,
 }
 
 func (d *fakeDatasource) WriteCurrentConfigHash(namespace string, hash string) {
-	d.hashes[namespace] = hash
+	d.confHashes[namespace] = hash
 }
 
 func (d *fakeDatasource) UpdateStatus(ctx context.Context, namespace string, status string) {
@@ -69,6 +69,6 @@ func (d *fakeDatasource) UpdateStatus(ctx context.Context, namespace string, sta
 // NewFakeDatasource returns a predefined set of namespaces + configs
 func NewFakeDatasource(ctx context.Context) Datasource {
 	return &fakeDatasource{
-		hashes: make(map[string]string),
+		confHashes: make(map[string]string),
 	}
 }

--- a/config-reloader/datasource/fs.go
+++ b/config-reloader/datasource/fs.go
@@ -16,7 +16,7 @@ import (
 )
 
 type fsDatasource struct {
-	hashes          map[string]string
+	confHashes      map[string]string
 	rootDir         string
 	statusOutputDir string
 }
@@ -41,7 +41,7 @@ func (d *fsDatasource) GetNamespaces(ctx context.Context) ([]*NamespaceConfig, e
 		cfg := &NamespaceConfig{
 			Name:               ns,
 			FluentdConfig:      string(contents),
-			PreviousConfigHash: d.hashes[ns],
+			PreviousConfigHash: d.confHashes[ns],
 		}
 
 		logrus.Infof("Loading namespace %s from file %s", ns, f)
@@ -52,7 +52,7 @@ func (d *fsDatasource) GetNamespaces(ctx context.Context) ([]*NamespaceConfig, e
 }
 
 func (d *fsDatasource) WriteCurrentConfigHash(namespace string, hash string) {
-	d.hashes[namespace] = hash
+	d.confHashes[namespace] = hash
 }
 
 func (d *fsDatasource) UpdateStatus(ctx context.Context, namespace string, status string) {
@@ -67,7 +67,7 @@ func (d *fsDatasource) UpdateStatus(ctx context.Context, namespace string, statu
 // NewFileSystemDatasource turns all files matching *.conf patter in the given dir into namespace configs
 func NewFileSystemDatasource(ctx context.Context, rootDir string, statusOutputDir string) Datasource {
 	return &fsDatasource{
-		hashes:          make(map[string]string),
+		confHashes:      make(map[string]string),
 		rootDir:         rootDir,
 		statusOutputDir: statusOutputDir,
 	}

--- a/config-reloader/go.mod
+++ b/config-reloader/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	k8s.io/api v0.21.4
 	k8s.io/apiextensions-apiserver v0.21.4
 	k8s.io/apimachinery v0.21.4

--- a/config-reloader/go.sum
+++ b/config-reloader/go.sum
@@ -257,6 +257,8 @@ github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/config-reloader/util/util.go
+++ b/config-reloader/util/util.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"github.com/mitchellh/hashstructure/v2"
 	"io/ioutil"
 	"os/exec"
 	"sort"
@@ -122,4 +123,24 @@ func TrimTrailingComment(line string) string {
 	}
 
 	return line
+}
+
+func MakeStructureHash(v interface{}) (uint64, error) {
+	hashV, err := hashstructure.Hash(v, hashstructure.FormatV2, nil)
+	if err != nil {
+		return hashV, err
+	}
+
+	return hashV, nil
+}
+
+func AreStructureHashEqual(v interface{}, f interface{}) bool {
+	hashV, _ := hashstructure.Hash(v, hashstructure.FormatV2, nil)
+	hashF, _ := hashstructure.Hash(f, hashstructure.FormatV2, nil)
+
+	if hashV != 0 && hashF != 0 {
+		return hashV == hashF
+	}
+
+	return false
 }

--- a/config-reloader/util/util_test.go
+++ b/config-reloader/util/util_test.go
@@ -9,6 +9,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type Mount struct {
+	Path       string
+	VolumeName string
+	SubPath    string
+}
+
+// MiniContainer container subset with the parent pod's metadata
+type MiniContainer struct {
+	// the pod id
+	PodID   string
+	PodName string
+
+	Image       string
+	ContainerID string
+
+	// pod labels
+	Labels map[string]string
+
+	// container name
+	Name string
+	// only the emptyDir mounts, never empty, sorted by len(Path), descending
+	HostMounts []*Mount
+
+	NodeName string
+}
+
 func TestMakeFluentdSafeName(t *testing.T) {
 	assert.Equal(t, "a", MakeFluentdSafeName("a"))
 	assert.Equal(t, "123", MakeFluentdSafeName("123"))
@@ -40,4 +66,50 @@ func TestTrimTrailingComment(t *testing.T) {
 	assert.Equal(t, "a", TrimTrailingComment("a #12451345"))
 	assert.Equal(t, "a", TrimTrailingComment("a"))
 	assert.Equal(t, "a", TrimTrailingComment("a#########"))
+}
+
+func TestMakeStructureHash(t *testing.T) {
+	mini1 := &MiniContainer{
+		PodID:       "4b519aaf-67f1-4588-8164-f679b2298e25",
+		PodName:     "kfo-log-router-nwxtj",
+		Name:        "config-reloader",
+		NodeName:    "vdp-dev-control-plane",
+		Image:       "testing/kfo:delete-problems-3",
+		ContainerID: "containerd://37dce75ed2f01c5f858b4c4cc96b23ebacaba6569af93ed64b3904be9a676cb1",
+	}
+
+	hashMini1, err := MakeStructureHash(mini1)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(0xa92a93a3863f8fd6), hashMini1)
+}
+
+func TestAreStructureHashEqual(t *testing.T) {
+	mini1 := &MiniContainer{
+		PodID:       "4b519aaf-67f1-4588-8164-f679b2298e25",
+		PodName:     "kfo-log-router-nwxtj",
+		Name:        "config-reloader",
+		NodeName:    "vdp-dev-control-plane",
+		Image:       "testing/kfo:delete-problems-3",
+		ContainerID: "containerd://37dce75ed2f01c5f858b4c4cc96b23ebacaba6569af93ed64b3904be9a676cb1",
+	}
+	mini2 := &MiniContainer{
+		PodID:       "4b519aaf-67f1-4588-8164-f679b2298e25",
+		PodName:     "kfo-log-router-nwxtj",
+		Name:        "config-reloader",
+		NodeName:    "vdp-dev-control-plane",
+		Image:       "testing/kfo:delete-problems-3",
+		ContainerID: "containerd://37dce75ed2f01c5f858b4c4cc96b23ebacaba6569af93ed64b3904be9a676cb1",
+	}
+	mini3 := &MiniContainer{
+		PodID:       "4b519aaf-67f1-4588-8164-f679b2298e25",
+		PodName:     "kfo-log-router-next",
+		Name:        "config-reloader",
+		NodeName:    "vdp-dev-control-plane",
+		Image:       "testing/kfo:delete-problems-3",
+		ContainerID: "containerd://37dce75ed2f01c5f858b4c4cc96b23ebacaba6569af93ed64b3904be9a676cb1",
+	}
+
+	assert.Equal(t, true, AreStructureHashEqual(mini1, mini2))
+	assert.NotEqual(t, true, AreStructureHashEqual(mini1, mini3))
+	assert.Equal(t, false, AreStructureHashEqual(mini1, mini3))
 }


### PR DESCRIPTION
 - add kube pod informer for pods add/rm in namespace we monitor, rerun preprocess configs
 - fixes #289
 - fixes #253
 - fixes issue with respecting `c.cfg.AnnotConfigmapName` on configmap namespaces discovery
 - introduces `hashstructure` package for smarter hashing of changing objects
 - make smarter hashing for `allConfigsHash` metahashing (without `reflect.DeepEqual()`)

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>