### PR TITLE
Fix cri-o Config when log line contains a json

### DIFF
--- a/config-reloader/templates/kubernetes.conf
+++ b/config-reloader/templates/kubernetes.conf
@@ -16,7 +16,7 @@
     format1 /^(?<partials>([^\n]+ (stdout|stderr) P [^\n]+\n)*)/
     format2 /(?<time>[^\n]+) (?<stream>stdout|stderr) F (?<log>[^\n]*)/
     # docker
-    format3 /|(?<json>{.*})/
+    format3 /|^(?<json>{.*})/
     time_format %Y-%m-%dT%H:%M:%S.%N%:z
   </parse>
 </source>


### PR DESCRIPTION
If a log line is distributed over multiple lines in cri-o (partials) and it contains `{` and `}` the docker part seems to win (for the partial).