### PR TITLE
Cleanup SERVERENGINE_SOCKETMANAGER socket files usually found in /tmp

### DIFF
--- a/base-image/plugins/in_just_exit.rb
+++ b/base-image/plugins/in_just_exit.rb
@@ -21,6 +21,7 @@ module Fluent
         # this means all input/filters are ok. User configs cannot
         # define sources so it's all safe
         # https://github.com/fluent/fluentd/blob/v1.2.2/lib/fluent/root_agent.rb#L171
+        Fluent::Supervisor.cleanup_resources
         Kernel.exit!(0)
       end
 


### PR DESCRIPTION
Fixes #105

Every time kube-fluentd-operator validates a fluentd config, it leaves behind a SERVERENGINE_SOCKETMANAGER socket file in /tmp.

```
ls -ltr /tmp
srwx------. 1 root root    0 Apr 16 00:03 SERVERENGINE_SOCKETMANAGER_2022-04-16T00:03:45Z_11491
srwx------. 1 root root    0 Apr 16 00:03 SERVERENGINE_SOCKETMANAGER_2022-04-16T00:03:46Z_11495
srwx------. 1 root root    0 Apr 16 00:03 SERVERENGINE_SOCKETMANAGER_2022-04-16T00:03:48Z_11499
srwx------. 1 root root    0 Apr 16 00:03 SERVERENGINE_SOCKETMANAGER_2022-04-16T00:03:49Z_11503
srwx------. 1 root root    0 Apr 16 00:03 SERVERENGINE_SOCKETMANAGER_2022-04-16T00:03:50Z_11505
```

The fix is to have just_exit plugin cleanup resources when it exists, so the socket files are not lingering.

The just_exit plugin can call Fluent::Supervisor.cleanup_resource, which should do the cleanup.
https://github.com/fluent/fluentd/blob/6927305ddf3d989aced39172599c9aeb5e697471/lib/fluent/supervisor.rb#L587