### PR TITLE
Reload Configuration only when a pod matching the label set in mounted-file is created or deleted

### DIFF
--- a/config-reloader/processors/labels_test.go
+++ b/config-reloader/processors/labels_test.go
@@ -12,24 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLabelsParseOk(t *testing.T) {
-	inputs := map[string]map[string]string{
-		"$labels(a=b,,,)":                  {"a": "b"},
-		"$labels(a=1, b=2)":                {"a": "1", "b": "2"},
-		"$labels(x=y,b=1)":                 {"b": "1", "x": "y"},
-		"$labels(x=1, b = 1)":              {"b": "1", "x": "1"},
-		"$labels(x=1, a=)":                 {"a": "", "x": "1"},
-		"$labels(hello/world=ok, a=value)": {"hello/world": "ok", "a": "value"},
-		"$labels(x=1, _container=main)":    {"_container": "main", "x": "1"},
-	}
-
-	for tag, result := range inputs {
-		processed, err := parseTagToLabels(tag)
-		assert.Nil(t, err, "Got an error instead: %+v", err)
-		assert.Equal(t, result, processed)
-	}
-}
-
 func TestSafeLabel(t *testing.T) {
 	// empty string is a valid label value
 	assert.Equal(t, "_", safeLabelValue(""))
@@ -39,30 +21,6 @@ func TestSafeLabel(t *testing.T) {
 	assert.Equal(t, "abc___", safeLabelValue("abc..."))
 	assert.Equal(t, "abc_def", safeLabelValue("abc.def"))
 	assert.Equal(t, "app_kubernetes_io/name=nginx_ingress", safeLabelValue("app.kubernetes.io/name=nginx-ingress"))
-}
-
-func TestLabelsParseNotOk(t *testing.T) {
-	inputs := []string{
-		"$labels",
-		"$labels()",
-		"$labels(=)",
-		"$labels(=f)",
-		"$labels(.=*)",
-		"$labels(a=.)",
-		"$labels(a==1)",
-		"$labels(-a=sfd)",
-		"$labels(a=-sfd)",
-		"$labels(a*=hello)",
-		"$labels(a=*)",
-		"$labels(a=1, =2)",
-		"$labels(_container=)", // empty container name
-		"$labels(app.kubernetes.io/name=*)",
-	}
-
-	for _, tag := range inputs {
-		res, err := parseTagToLabels(tag)
-		assert.NotNil(t, err, "Got this instead for %s: %+v", tag, res)
-	}
 }
 
 func TestLabelNoLabels(t *testing.T) {

--- a/config-reloader/processors/mounted_file.go
+++ b/config-reloader/processors/mounted_file.go
@@ -43,7 +43,7 @@ func (state *mountedFileState) Prepare(input fluentd.Fragment) (fluentd.Fragment
 			}
 			paramLabels = util.TrimTrailingComment(paramLabels)
 
-			labels, err := parseTagToLabels(fmt.Sprintf("$labels(%s)", paramLabels))
+			labels, err := util.ParseTagToLabels(fmt.Sprintf("$labels(%s)", paramLabels))
 			if err != nil {
 				return nil, err
 			}
@@ -53,7 +53,7 @@ func (state *mountedFileState) Prepare(input fluentd.Fragment) (fluentd.Fragment
 			var addedLabels map[string]string
 			if paramAddedLabels != "" {
 				// no added labels is just fine
-				addedLabels, err = parseTagToLabels(fmt.Sprintf("$labels(%s)", paramAddedLabels))
+				addedLabels, err = util.ParseTagToLabels(fmt.Sprintf("$labels(%s)", paramAddedLabels))
 				if err != nil {
 					return nil, err
 				}
@@ -86,18 +86,7 @@ func (state *mountedFileState) Prepare(input fluentd.Fragment) (fluentd.Fragment
 }
 
 func matches(spec *ContainerFile, mini *datasource.MiniContainer) bool {
-	for k, v := range spec.Labels {
-		contValue := mini.Labels[k]
-		if k == "_container" {
-			contValue = mini.Name
-		}
-
-		if v != contValue {
-			return false
-		}
-	}
-
-	return true
+	return util.Match(spec.Labels, mini.Labels, mini.Name)
 }
 
 func (state *mountedFileState) convertToFragement(cf *ContainerFile) fluentd.Fragment {

--- a/config-reloader/processors/thisns.go
+++ b/config-reloader/processors/thisns.go
@@ -5,6 +5,7 @@ package processors
 
 import (
 	"fmt"
+	"github.com/vmware/kube-fluentd-operator/config-reloader/util"
 	"strings"
 
 	"github.com/vmware/kube-fluentd-operator/config-reloader/fluentd"
@@ -42,7 +43,7 @@ func (p *expandThisnsMacroState) Process(input fluentd.Fragment) (fluentd.Fragme
 			return nil
 		}
 
-		if strings.HasPrefix(d.Tag, macroLabels) || strings.HasPrefix(d.Tag, macroUniqueTag) {
+		if strings.HasPrefix(d.Tag, util.MacroLabels) || strings.HasPrefix(d.Tag, macroUniqueTag) {
 			// Let other processors handle this
 			return nil
 		}

--- a/config-reloader/util/util_test.go
+++ b/config-reloader/util/util_test.go
@@ -41,3 +41,45 @@ func TestTrimTrailingComment(t *testing.T) {
 	assert.Equal(t, "a", TrimTrailingComment("a"))
 	assert.Equal(t, "a", TrimTrailingComment("a#########"))
 }
+
+func TestLabelsParseOk(t *testing.T) {
+	inputs := map[string]map[string]string{
+		"$labels(a=b,,,)":                  {"a": "b"},
+		"$labels(a=1, b=2)":                {"a": "1", "b": "2"},
+		"$labels(x=y,b=1)":                 {"b": "1", "x": "y"},
+		"$labels(x=1, b = 1)":              {"b": "1", "x": "1"},
+		"$labels(x=1, a=)":                 {"a": "", "x": "1"},
+		"$labels(hello/world=ok, a=value)": {"hello/world": "ok", "a": "value"},
+		"$labels(x=1, _container=main)":    {"_container": "main", "x": "1"},
+	}
+
+	for tag, result := range inputs {
+		processed, err := ParseTagToLabels(tag)
+		assert.Nil(t, err, "Got an error instead: %+v", err)
+		assert.Equal(t, result, processed)
+	}
+}
+
+func TestLabelsParseNotOk(t *testing.T) {
+	inputs := []string{
+		"$labels",
+		"$labels()",
+		"$labels(=)",
+		"$labels(=f)",
+		"$labels(.=*)",
+		"$labels(a=.)",
+		"$labels(a==1)",
+		"$labels(-a=sfd)",
+		"$labels(a=-sfd)",
+		"$labels(a*=hello)",
+		"$labels(a=*)",
+		"$labels(a=1, =2)",
+		"$labels(_container=)", // empty container name
+		"$labels(app.kubernetes.io/name=*)",
+	}
+
+	for _, tag := range inputs {
+		res, err := ParseTagToLabels(tag)
+		assert.NotNil(t, err, "Got this instead for %s: %+v", tag, res)
+	}
+}


### PR DESCRIPTION
According to the [issue comments](https://github.com/vmware/kube-fluentd-operator/issues/289#issuecomment-1141027421), the existing solution caused too many configuration reloads.
This is because the configuration reload occurred whenever every pod was created (or deleted). So it is not affordable for a large cluster.
So, make the configuration reload only when a pod with the label set in the mounted-file is created (or deleted).