### PR TITLE
Reload Configuration only when a pod matching the label set in mounted-file is created or deleted.

### DIFF
--- a/config-reloader/datasource/kube_informer.go
+++ b/config-reloader/datasource/kube_informer.go
@@ -3,8 +3,11 @@ package datasource
 import (
 	"context"
 	"fmt"
+	"github.com/vmware/kube-fluentd-operator/config-reloader/fluentd"
+	"github.com/vmware/kube-fluentd-operator/config-reloader/util"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -25,14 +28,16 @@ import (
 )
 
 type kubeInformerConnection struct {
-	client  kubernetes.Interface
-	hashes  map[string]string
-	cfg     *config.Config
-	kubeds  kubedatasource.KubeDS
-	nslist  listerv1.NamespaceLister
-	podlist listerv1.PodLister
-	cmlist  listerv1.ConfigMapLister
-	fdlist  kfoListersV1beta1.FluentdConfigLister
+	client        kubernetes.Interface
+	confHashes    map[string]string
+	mountedLabels map[string][]map[string]string
+	cfg           *config.Config
+	kubeds        kubedatasource.KubeDS
+	nslist        listerv1.NamespaceLister
+	podlist       listerv1.PodLister
+	cmlist        listerv1.ConfigMapLister
+	fdlist        kfoListersV1beta1.FluentdConfigLister
+	updateChan    chan time.Time
 }
 
 // GetNamespaces queries the configured Kubernetes API to generate a list of NamespaceConfig objects.
@@ -58,6 +63,26 @@ func (d *kubeInformerConnection) GetNamespaces(ctx context.Context) ([]*Namespac
 			return nil, err
 		}
 
+		fragment, err := fluentd.ParseString(configdata)
+		if err != nil {
+			return nil, err
+		}
+
+		var mountedLabels []map[string]string
+		for _, frag := range fragment {
+			if frag.Name == "source" && frag.Type() == "mounted-file" {
+				paramLabels := frag.Param("labels")
+				paramLabels = util.TrimTrailingComment(paramLabels)
+				currLabels, err := util.ParseTagToLabels(fmt.Sprintf("$labels(%s)", paramLabels))
+				if err != nil {
+					return nil, err
+				}
+				mountedLabels = append(mountedLabels, currLabels)
+			}
+		}
+
+		d.updateMountedLabels(ns, mountedLabels)
+
 		// Create a compact representation of the pods running in the namespace
 		// under consideration
 		pods, err := d.podlist.Pods(ns).List(labels.NewSelector())
@@ -77,7 +102,7 @@ func (d *kubeInformerConnection) GetNamespaces(ctx context.Context) ([]*Namespac
 		nsconfigs = append(nsconfigs, &NamespaceConfig{
 			Name:               ns,
 			FluentdConfig:      configdata,
-			PreviousConfigHash: d.hashes[ns],
+			PreviousConfigHash: d.confHashes[ns],
 			Labels:             nsobj.Labels,
 			MiniContainers:     minis,
 		})
@@ -88,7 +113,11 @@ func (d *kubeInformerConnection) GetNamespaces(ctx context.Context) ([]*Namespac
 
 // WriteCurrentConfigHash is a setter for the hashtable maintained by this Datasource
 func (d *kubeInformerConnection) WriteCurrentConfigHash(namespace string, hash string) {
-	d.hashes[namespace] = hash
+	d.confHashes[namespace] = hash
+}
+
+func (d *kubeInformerConnection) updateMountedLabels(namespace string, labels []map[string]string) {
+	d.mountedLabels[namespace] = labels
 }
 
 // UpdateStatus updates a namespace's status annotation with the latest result
@@ -168,6 +197,13 @@ func (d *kubeInformerConnection) discoverNamespaces(ctx context.Context) ([]stri
 				for _, cfmap := range confMapsList {
 					if cfmap.ObjectMeta.Name == d.cfg.DefaultConfigmapName {
 						namespaces = append(namespaces, cfmap.ObjectMeta.Namespace)
+					} else {
+						// We need to find configmaps that honor the global annotation for configmaps:
+						configMapNamespace, _ := d.nslist.Get(cfmap.ObjectMeta.Namespace)
+						configMapName := configMapNamespace.Annotations[d.cfg.AnnotConfigmapName]
+						if configMapName != "" {
+							namespaces = append(namespaces, cfmap.ObjectMeta.Namespace)
+						}
 					}
 				}
 			} else {
@@ -195,6 +231,39 @@ func (d *kubeInformerConnection) discoverNamespaces(ctx context.Context) ([]stri
 	// Sort the namespaces:
 	sort.Strings(nsList)
 	return nsList, nil
+}
+
+func (d *kubeInformerConnection) handlePodChange(ctx context.Context, obj interface{}) {
+	mObj := obj.(*core.Pod)
+	logrus.Infof("Detected pod change %s in namespace: %s", mObj.GetName(), mObj.GetNamespace())
+	configdata, err := d.kubeds.GetFluentdConfig(ctx, mObj.GetNamespace())
+	nsConfigStr := fmt.Sprintf("%#v", configdata)
+
+	if err == nil {
+		if strings.Contains(nsConfigStr, "mounted-file") {
+			podLabels := mObj.GetLabels()
+			mountedLabel := d.mountedLabels[mObj.GetNamespace()]
+			for _, container := range mObj.Spec.Containers {
+				if matchAny(podLabels, mountedLabel, container.Name) {
+					logrus.Infof("Detected mounted-file pod change %s in namespace: %s", mObj.GetName(), mObj.GetNamespace())
+					select {
+					case d.updateChan <- time.Now():
+					default:
+					}
+				}
+			}
+		}
+	}
+}
+
+func matchAny(contLabels map[string]string, mountedLabelsInNs []map[string]string, name string) bool {
+	for _, mountedLabels := range mountedLabelsInNs {
+		if util.Match(mountedLabels, contLabels, name) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // NewKubernetesInformerDatasource builds a new Datasource from the provided config.
@@ -263,14 +332,29 @@ func NewKubernetesInformerDatasource(ctx context.Context, cfg *config.Config, up
 	}
 	logrus.Infof("Synced local informer with upstream Kubernetes API")
 
-	return &kubeInformerConnection{
-		client:  client,
-		hashes:  make(map[string]string),
-		cfg:     cfg,
-		kubeds:  kubeds,
-		nslist:  namespaceLister,
-		podlist: podLister,
-		cmlist:  cmLister,
-		fdlist:  fluentdconfigDSLister.Fdlist,
-	}, nil
+	kubeInfoCx := &kubeInformerConnection{
+		client:        client,
+		confHashes:    make(map[string]string),
+		mountedLabels: make(map[string][]map[string]string),
+		cfg:           cfg,
+		kubeds:        kubeds,
+		nslist:        namespaceLister,
+		podlist:       podLister,
+		cmlist:        cmLister,
+		fdlist:        fluentdconfigDSLister.Fdlist,
+		updateChan:    updateChan,
+	}
+
+	factory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			kubeInfoCx.handlePodChange(ctx, obj)
+		},
+		UpdateFunc: func(old, obj interface{}) {
+		},
+		DeleteFunc: func(obj interface{}) {
+			kubeInfoCx.handlePodChange(ctx, obj)
+		},
+	})
+
+	return kubeInfoCx, nil
 }

--- a/config-reloader/processors/labels_test.go
+++ b/config-reloader/processors/labels_test.go
@@ -12,24 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLabelsParseOk(t *testing.T) {
-	inputs := map[string]map[string]string{
-		"$labels(a=b,,,)":                  {"a": "b"},
-		"$labels(a=1, b=2)":                {"a": "1", "b": "2"},
-		"$labels(x=y,b=1)":                 {"b": "1", "x": "y"},
-		"$labels(x=1, b = 1)":              {"b": "1", "x": "1"},
-		"$labels(x=1, a=)":                 {"a": "", "x": "1"},
-		"$labels(hello/world=ok, a=value)": {"hello/world": "ok", "a": "value"},
-		"$labels(x=1, _container=main)":    {"_container": "main", "x": "1"},
-	}
-
-	for tag, result := range inputs {
-		processed, err := parseTagToLabels(tag)
-		assert.Nil(t, err, "Got an error instead: %+v", err)
-		assert.Equal(t, result, processed)
-	}
-}
-
 func TestSafeLabel(t *testing.T) {
 	// empty string is a valid label value
 	assert.Equal(t, "_", safeLabelValue(""))
@@ -39,30 +21,6 @@ func TestSafeLabel(t *testing.T) {
 	assert.Equal(t, "abc___", safeLabelValue("abc..."))
 	assert.Equal(t, "abc_def", safeLabelValue("abc.def"))
 	assert.Equal(t, "app_kubernetes_io/name=nginx_ingress", safeLabelValue("app.kubernetes.io/name=nginx-ingress"))
-}
-
-func TestLabelsParseNotOk(t *testing.T) {
-	inputs := []string{
-		"$labels",
-		"$labels()",
-		"$labels(=)",
-		"$labels(=f)",
-		"$labels(.=*)",
-		"$labels(a=.)",
-		"$labels(a==1)",
-		"$labels(-a=sfd)",
-		"$labels(a=-sfd)",
-		"$labels(a*=hello)",
-		"$labels(a=*)",
-		"$labels(a=1, =2)",
-		"$labels(_container=)", // empty container name
-		"$labels(app.kubernetes.io/name=*)",
-	}
-
-	for _, tag := range inputs {
-		res, err := parseTagToLabels(tag)
-		assert.NotNil(t, err, "Got this instead for %s: %+v", tag, res)
-	}
 }
 
 func TestLabelNoLabels(t *testing.T) {

--- a/config-reloader/processors/mounted_file.go
+++ b/config-reloader/processors/mounted_file.go
@@ -43,7 +43,7 @@ func (state *mountedFileState) Prepare(input fluentd.Fragment) (fluentd.Fragment
 			}
 			paramLabels = util.TrimTrailingComment(paramLabels)
 
-			labels, err := parseTagToLabels(fmt.Sprintf("$labels(%s)", paramLabels))
+			labels, err := util.ParseTagToLabels(fmt.Sprintf("$labels(%s)", paramLabels))
 			if err != nil {
 				return nil, err
 			}
@@ -53,7 +53,7 @@ func (state *mountedFileState) Prepare(input fluentd.Fragment) (fluentd.Fragment
 			var addedLabels map[string]string
 			if paramAddedLabels != "" {
 				// no added labels is just fine
-				addedLabels, err = parseTagToLabels(fmt.Sprintf("$labels(%s)", paramAddedLabels))
+				addedLabels, err = util.ParseTagToLabels(fmt.Sprintf("$labels(%s)", paramAddedLabels))
 				if err != nil {
 					return nil, err
 				}
@@ -86,18 +86,7 @@ func (state *mountedFileState) Prepare(input fluentd.Fragment) (fluentd.Fragment
 }
 
 func matches(spec *ContainerFile, mini *datasource.MiniContainer) bool {
-	for k, v := range spec.Labels {
-		contValue := mini.Labels[k]
-		if k == "_container" {
-			contValue = mini.Name
-		}
-
-		if v != contValue {
-			return false
-		}
-	}
-
-	return true
+	return util.Match(spec.Labels, mini.Labels, mini.Name)
 }
 
 func (state *mountedFileState) convertToFragement(cf *ContainerFile) fluentd.Fragment {

--- a/config-reloader/processors/thisns.go
+++ b/config-reloader/processors/thisns.go
@@ -5,6 +5,7 @@ package processors
 
 import (
 	"fmt"
+	"github.com/vmware/kube-fluentd-operator/config-reloader/util"
 	"strings"
 
 	"github.com/vmware/kube-fluentd-operator/config-reloader/fluentd"
@@ -42,7 +43,7 @@ func (p *expandThisnsMacroState) Process(input fluentd.Fragment) (fluentd.Fragme
 			return nil
 		}
 
-		if strings.HasPrefix(d.Tag, macroLabels) || strings.HasPrefix(d.Tag, macroUniqueTag) {
+		if strings.HasPrefix(d.Tag, util.MacroLabels) || strings.HasPrefix(d.Tag, macroUniqueTag) {
 			// Let other processors handle this
 			return nil
 		}

--- a/config-reloader/util/util_test.go
+++ b/config-reloader/util/util_test.go
@@ -41,3 +41,45 @@ func TestTrimTrailingComment(t *testing.T) {
 	assert.Equal(t, "a", TrimTrailingComment("a"))
 	assert.Equal(t, "a", TrimTrailingComment("a#########"))
 }
+
+func TestLabelsParseOk(t *testing.T) {
+	inputs := map[string]map[string]string{
+		"$labels(a=b,,,)":                  {"a": "b"},
+		"$labels(a=1, b=2)":                {"a": "1", "b": "2"},
+		"$labels(x=y,b=1)":                 {"b": "1", "x": "y"},
+		"$labels(x=1, b = 1)":              {"b": "1", "x": "1"},
+		"$labels(x=1, a=)":                 {"a": "", "x": "1"},
+		"$labels(hello/world=ok, a=value)": {"hello/world": "ok", "a": "value"},
+		"$labels(x=1, _container=main)":    {"_container": "main", "x": "1"},
+	}
+
+	for tag, result := range inputs {
+		processed, err := ParseTagToLabels(tag)
+		assert.Nil(t, err, "Got an error instead: %+v", err)
+		assert.Equal(t, result, processed)
+	}
+}
+
+func TestLabelsParseNotOk(t *testing.T) {
+	inputs := []string{
+		"$labels",
+		"$labels()",
+		"$labels(=)",
+		"$labels(=f)",
+		"$labels(.=*)",
+		"$labels(a=.)",
+		"$labels(a==1)",
+		"$labels(-a=sfd)",
+		"$labels(a=-sfd)",
+		"$labels(a*=hello)",
+		"$labels(a=*)",
+		"$labels(a=1, =2)",
+		"$labels(_container=)", // empty container name
+		"$labels(app.kubernetes.io/name=*)",
+	}
+
+	for _, tag := range inputs {
+		res, err := ParseTagToLabels(tag)
+		assert.NotNil(t, err, "Got this instead for %s: %+v", tag, res)
+	}
+}


### PR DESCRIPTION
According to the [issue comments](https://github.com/vmware/kube-fluentd-operator/issues/289#issuecomment-1141027421), the existing solution caused too many configuration reloads.
This is because the configuration reload occurred whenever every pod was created (or deleted). So it is not affordable for a large cluster.
So, make the configuration reload only when a pod with the label set in the mounted-file is created (or deleted).