### PR TITLE
Fix discovery of fluentdconfig if migration mode is enabled

### DIFF
--- a/config-reloader/datasource/kube_informer.go
+++ b/config-reloader/datasource/kube_informer.go
@@ -88,6 +88,10 @@ func NewKubernetesInformerDatasource(ctx context.Context, cfg *config.Config, up
 			if err != nil {
 				return nil, err
 			}
+			fluentdconfigDSLister =
+				&kubedatasource.FluentdConfigDS{
+					Fdlist: kubeds.GetFdlist(),
+				}
 		} else {
 			kubeds, err = kubedatasource.NewConfigMapDS(ctx, cfg, factory, updateChan)
 			if err != nil {

--- a/config-reloader/datasource/kubedatasource/migrationmode.go
+++ b/config-reloader/datasource/kubedatasource/migrationmode.go
@@ -59,5 +59,5 @@ func (m *MigrationModeDS) GetFluentdConfig(ctx context.Context, namespace string
 
 // GetFdlist return nil for this mode because it does not use CRDs:
 func (m *MigrationModeDS) GetFdlist() kfoListersV1beta1.FluentdConfigLister {
-	return nil
+	return m.fdKubeDS.GetFdlist()
 }


### PR DESCRIPTION
There is a small bug in #310 which gives always the error `"Failed to initialize the fluentdconfig crd client, d.fclient = nil"`.