### PR TITLE
feat: avoid use empty configmaps

### DIFF
--- a/config-reloader/datasource/kube_informer.go
+++ b/config-reloader/datasource/kube_informer.go
@@ -160,7 +160,10 @@ func (d *kubeInformerConnection) GetNamespaces(ctx context.Context) ([]*Namespac
 		if err != nil {
 			return nil, err
 		}
-
+		if configdata == "" {
+			logrus.Infof("Skipping namespace: %v because is empty", ns)
+			continue
+		}
 		fragment, err := fluentd.ParseString(configdata)
 		if err != nil {
 			return nil, err

--- a/config-reloader/datasource/kubedatasource/configmap.go
+++ b/config-reloader/datasource/kubedatasource/configmap.go
@@ -143,6 +143,7 @@ func (c *ConfigMapDS) readConfig(configmaps []*core.ConfigMap) string {
 			logrus.Debugf("Loaded config data from config map: %s/%s", cm.ObjectMeta.Namespace, cm.ObjectMeta.Name)
 		} else {
 			logrus.Warnf("cannot find entry %s in configmap %s/%s", entryName, cm.ObjectMeta.Namespace, cm.ObjectMeta.Name)
+			return ""
 		}
 	}
 	return strings.Join(configdata, "\n")


### PR DESCRIPTION
Avoid use empty configmaps in fluentd