### PR TITLE
fix: add follow_inode to wildcard

### DIFF
--- a/config-reloader/templates/kubernetes.conf
+++ b/config-reloader/templates/kubernetes.conf
@@ -12,6 +12,7 @@
   read_from_head true
   read_bytes_limit_per_second {{.ReadBytesLimit}}
   multiline_flush_interval 5s
+  follow_inodes true
   <parse>
     @type multiline
     # cri-o


### PR DESCRIPTION
- add follow_inode to wildcard as recommended by the docs

```
Avoid to read rotated files duplicately. You should set true when you use * or strftime format in path.
```