### PR TITLE
Fix  error while --set reloader.extraEnv.elk_port=<numeric value>

### DIFF
--- a/charts/log-router/templates/secret.yaml
+++ b/charts/log-router/templates/secret.yaml
@@ -18,9 +18,9 @@ metadata:
 type: Opaque
 data:
 {{- range $key, $value := .Values.fluentd.extraEnv }}
-  fluentd.{{ $key }}: {{ $value | b64enc | quote }}
+  fluentd.{{ $key }}: {{ $value | toString | b64enc | quote }}
 {{- end }}
 {{- range $key, $value := .Values.reloader.extraEnv }}
-  reloader.{{ $key }}: {{ $value | b64enc | quote }}
+  reloader.{{ $key }}: {{ $value | toString | b64enc | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
If you are trying to set numeric values to extraEnv, like
--set fluentd.extraEnv.elk_host="ELK_HOST" --set fluentd.extraEnv.elk_port="9200" --set fluentd.extraEnv.elk_user="user",
helm gives an error.