### PR TITLE
Support setting fs-dir for fs datasource

### DIFF
--- a/charts/log-router/templates/daemonset.yaml
+++ b/charts/log-router/templates/daemonset.yaml
@@ -143,6 +143,9 @@ spec:
           {{- if .Values.adminNamespace }}
           - --admin-namespace={{ .Values.adminNamespace }}
           {{- end }}
+          {{- if eq .Values.datasource "fs" }}
+          - --fs-dir={{ required "fsDatasourceDir is required for fs datasource" .Values.fsDatasourceDir }}
+          {{- end }}
           volumeMounts:
           - name: fluentconf
             mountPath: /fluentd/etc

--- a/charts/log-router/values.yaml
+++ b/charts/log-router/values.yaml
@@ -28,6 +28,9 @@ crdMigrationMode: false
 
 defaultConfigmap: "fluentd-config"
 
+# Use with datasource: fs, the fsDataSourceDir will be used for finding config files
+fsDatasourceDir: ""
+
 image:
   repository: vmware/kube-fluentd-operator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
We had a control plane meltdown when starting KFO on a GKE cluster with 1000s of nodes as reloader will make several kube api calls at the same time when DaemonSet pods start at the same time. In order to mitigate this issue we are planning to go with `fs` datasource with configs read from a volume mount. But the current helm chart doesn't have an option to set required `--fs-dir` arg when `datasource: fs` is used. This PR is to add an option to set `fs-dir` in helm so that we can use `fs` datasoiurce.